### PR TITLE
Beta Testing List: allow more formatting with Markdown

### DIFF
--- a/admin/jpbeta-admin-main.php
+++ b/admin/jpbeta-admin-main.php
@@ -40,6 +40,18 @@ $testing_checklist = jpbeta_get_testing_list();
 		list-style-type: none;
 	}
 
+	.j-beta-wrap .card pre code {
+		display: block;
+	}
+
+	.j-beta-wrap .card pre {
+		white-space: pre-wrap;       /* css-3 */
+		white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+		white-space: -pre-wrap;      /* Opera 4-6 */
+		white-space: -o-pre-wrap;    /* Opera 7 */
+		word-wrap: break-word;       /* Internet Explorer 5.5+ */
+	}
+
 	.jetpack_page_jetpack-beta .card .feedback {
 		margin-top: 20px;
 		font-size: 18px;

--- a/admin/jpbeta-admin-main.php
+++ b/admin/jpbeta-admin-main.php
@@ -32,6 +32,14 @@ $testing_checklist = jpbeta_get_testing_list();
 		margin-top: 15px;
 	}
 
+	.jetpack_page_jetpack-beta .card ul {
+		list-style-type: disc;
+	}
+
+	.jetpack_page_jetpack-beta .card #jp_beta_choose_type ul {
+		list-style-type: none;
+	}
+
 	.jetpack_page_jetpack-beta .card .feedback {
 		margin-top: 20px;
 		font-size: 18px;

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -96,7 +96,7 @@ function load_debug_bar_jpa_info() {
 add_action( 'admin_init', 'load_debug_bar_jpa_info' );
 
 function jpbeta_get_testing_list() {
-	$test_list_path = WP_PLUGIN_DIR . '/jetpack/to-test.txt';
+	$test_list_path = WP_PLUGIN_DIR . '/jetpack/to-test.md';
 	if ( ! file_exists( $test_list_path ) ) {
 	    return "You're not currently using a beta version of Jetpack";
 	}

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -126,7 +126,10 @@ function jpbeta_get_testing_list() {
 		unset( $test_list_rows[1] );
 		unset( $test_list_rows[2] );
 
-		$o = '';
+		$o = sprintf(
+			__( "<h2>Please <a href='%s'>enable Jetpack's Markdown Module</a> for a better display of this list.</h2>", 'jpbeta' ),
+			Jetpack::admin_url( 'page=jetpack_modules' )
+		);
 
 		foreach( $test_list_rows as $row ) {
 			if( strpos( $row, '===' ) === 0 ) {


### PR DESCRIPTION
Jetpack includes a Markdown module: let's use it to make the Testing list look better, include links, images, code snippets, and everything we want!

If the Markdown module isn't enabled, the list will be displayed anyway, but a notice will be displayed at the top of the page, inviting people to activate the module for a better display.