### PR TITLE
Avoid errors when the plugin is installed manually.

### DIFF
--- a/autoupdate-self.php
+++ b/autoupdate-self.php
@@ -26,9 +26,9 @@ class Jetpack_Beta_Autoupdate_Self {
 		}
 
 		$this->config = array(
-			'plugin_file'        => JPBETA__PLUGIN_BASENAME . '/jetpack-beta.php',
-			'slug'               => JPBETA__PLUGIN_BASENAME,
-			'proper_folder_name' => JPBETA__PLUGIN_BASENAME,
+			'plugin_file'        => JPBETA__PLUGIN_FOLDER . '/jetpack-beta.php',
+			'slug'               => JPBETA__PLUGIN_FOLDER,
+			'proper_folder_name' => JPBETA__PLUGIN_FOLDER,
 			'api_url'            => 'https://api.github.com/repos/Automattic/jetpack-beta',
 			'github_url'         => 'https://github.com/Automattic/jetpack-beta',
 			'requires'           => '4.7',

--- a/autoupdate-self.php
+++ b/autoupdate-self.php
@@ -26,9 +26,9 @@ class Jetpack_Beta_Autoupdate_Self {
 		}
 
 		$this->config = array(
-			'plugin_file'        => 'jetpack-beta/jetpack-beta.php',
-			'slug'               => 'jetpack-beta',
-			'proper_folder_name' => 'jetpack-beta',
+			'plugin_file'        => 'jetpack-beta-master/jetpack-beta.php',
+			'slug'               => 'jetpack-beta-master',
+			'proper_folder_name' => 'jetpack-beta-master',
 			'api_url'            => 'https://api.github.com/repos/Automattic/jetpack-beta',
 			'github_url'         => 'https://github.com/Automattic/jetpack-beta',
 			'requires'           => '4.7',
@@ -180,7 +180,7 @@ class Jetpack_Beta_Autoupdate_Self {
 		}
 		return $source;
 	}
-	
+
 	public function auto_update_jetpack_beta( $update, $item ) {
 		if ( 'sure' !== get_option( 'jp_beta_autoupdate') ) {
 			return $update;

--- a/autoupdate-self.php
+++ b/autoupdate-self.php
@@ -26,9 +26,9 @@ class Jetpack_Beta_Autoupdate_Self {
 		}
 
 		$this->config = array(
-			'plugin_file'        => 'jetpack-beta-master/jetpack-beta.php',
-			'slug'               => 'jetpack-beta-master',
-			'proper_folder_name' => 'jetpack-beta-master',
+			'plugin_file'        => JPBETA__PLUGIN_BASENAME . '/jetpack-beta.php',
+			'slug'               => JPBETA__PLUGIN_BASENAME,
+			'proper_folder_name' => JPBETA__PLUGIN_BASENAME,
 			'api_url'            => 'https://api.github.com/repos/Automattic/jetpack-beta',
 			'github_url'         => 'https://github.com/Automattic/jetpack-beta',
 			'requires'           => '4.7',

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -17,7 +17,7 @@ class Jetpack_Beta_Admin {
 		add_action( "load-$hook", array( __CLASS__, 'admin_page_load' ) );
 		add_action( "admin_print_styles-$hook", array( __CLASS__, 'admin_styles' ) );
 		add_action( "admin_print_scripts-$hook", array( __CLASS__, 'admin_scripts' ) );
-		add_filter( 'plugin_action_links_' . JPBETA__PLUGIN_BASENAME . '/jetpack-beta.php', array( __CLASS__, 'admin_plugin_settings_link' ) );
+		add_filter( 'plugin_action_links_' . JPBETA__PLUGIN_FOLDER . '/jetpack-beta.php', array( __CLASS__, 'admin_plugin_settings_link' ) );
 	}
 
 	static function get_page_hook() {

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -17,7 +17,7 @@ class Jetpack_Beta_Admin {
 		add_action( "load-$hook", array( __CLASS__, 'admin_page_load' ) );
 		add_action( "admin_print_styles-$hook", array( __CLASS__, 'admin_styles' ) );
 		add_action( "admin_print_scripts-$hook", array( __CLASS__, 'admin_scripts' ) );
-		add_filter( 'plugin_action_links_' . plugin_basename( 'jetpack-beta-master/jetpack-beta.php' ), array( __CLASS__, 'admin_plugin_settings_link' ) );
+		add_filter( 'plugin_action_links_' . JPBETA__PLUGIN_BASENAME . '/jetpack-beta.php', array( __CLASS__, 'admin_plugin_settings_link' ) );
 	}
 
 	static function get_page_hook() {

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -17,7 +17,7 @@ class Jetpack_Beta_Admin {
 		add_action( "load-$hook", array( __CLASS__, 'admin_page_load' ) );
 		add_action( "admin_print_styles-$hook", array( __CLASS__, 'admin_styles' ) );
 		add_action( "admin_print_scripts-$hook", array( __CLASS__, 'admin_scripts' ) );
-		add_filter( 'plugin_action_links_' . plugin_basename( 'jetpack-beta/jetpack-beta.php' ), array( __CLASS__, 'admin_plugin_settings_link' ) );
+		add_filter( 'plugin_action_links_' . plugin_basename( 'jetpack-beta-master/jetpack-beta.php' ), array( __CLASS__, 'admin_plugin_settings_link' ) );
 	}
 
 	static function get_page_hook() {

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Jetpack beta manages files inside jetpack-dev folder this folder should contain
  *
  */
-define( 'JPBETA__PLUGIN_FOLDER', plugins_url() . '/jetpack-beta/' );
+define( 'JPBETA__PLUGIN_FOLDER', plugins_url() . '/jetpack-beta-master/' );
 define( 'JPBETA__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JPBETA__PLUGIN_FILE', __FILE__ );
 define( 'JPBETA_VERSION', 2 );

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -35,9 +35,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Jetpack beta manages files inside jetpack-dev folder this folder should contain
  *
  */
-define( 'JPBETA__PLUGIN_FOLDER', plugins_url() . '/jetpack-beta-master/' );
+define( 'JPBETA__PLUGIN_FOLDER', plugin_dir_url( __FILE__ ) );
 define( 'JPBETA__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JPBETA__PLUGIN_FILE', __FILE__ );
+define( 'JPBETA__PLUGIN_BASENAME', dirname( plugin_basename( __FILE__ ) ) );
 define( 'JPBETA_VERSION', 2 );
 
 define( 'JPBETA_DEFAULT_BRANCH', 'rc_only' );

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -35,10 +35,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Jetpack beta manages files inside jetpack-dev folder this folder should contain
  *
  */
-define( 'JPBETA__PLUGIN_FOLDER', plugin_dir_url( __FILE__ ) );
+define( 'JPBETA__PLUGIN_FOLDER',  basename( __DIR__ ) );
 define( 'JPBETA__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JPBETA__PLUGIN_FILE', __FILE__ );
-define( 'JPBETA__PLUGIN_BASENAME', dirname( plugin_basename( __FILE__ ) ) );
 define( 'JPBETA_VERSION', 2 );
 
 define( 'JPBETA_DEFAULT_BRANCH', 'rc_only' );


### PR DESCRIPTION
Fixes #20

When installing the plugin via the zip file generated from GitHub,
the directory name is jetpack-beta-master. We should use that naming convention in the plugin as well.