### PR TITLE
Testing help: add tips to help folks get started with testing.

### DIFF
--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -141,7 +141,7 @@ class Jetpack_Beta_Admin {
 	 * General rules and recommendations for new Beta Testers.
 	 * Displayed when no specific branch is picked.
 	 *
-	 * @since 2.1.0
+	 * @since 2.5.0
 	 */
 	static function to_test_general_rules_content() {
 		$test_rules = WP_PLUGIN_DIR . '/' . Jetpack_Beta::get_plugin_slug() . '/docs/testing/testing-tips.md';

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -128,11 +128,28 @@ class Jetpack_Beta_Admin {
 				return self::to_test_pr_content( $branch );
 				break;
 			case 'master':
+				return self::to_test_general_rules_content();
+				break;
 			case 'rc':
 				return self::to_test_file_content();
 				break;
 		}
 		return null;
+	}
+
+	/**
+	 * General rules and recommendations for new Beta Testers.
+	 * Displayed when no specific branch is picked.
+	 *
+	 * @since 2.1.0
+	 */
+	static function to_test_general_rules_content() {
+		$test_rules = WP_PLUGIN_DIR . '/' . Jetpack_Beta::get_plugin_slug() . '/docs/testing/testing-tips.md';
+		if ( ! file_exists( $test_rules ) ) {
+			return;
+		}
+		$content = file_get_contents( $test_rules );
+		return self::render_markdown( $content );
 	}
 
 	static function to_test_file_content() {


### PR DESCRIPTION
That information will appear when folks land on the Jetpack > Beta page
and when they haven't selected a testing branch yet.

This relies on the following PR:
https://github.com/Automattic/jetpack/pull/7032

It also makes sure to let people know they shouldn't test on a production site, as discussed here:
https://github.com/Automattic/jetpack-beta/pull/22#issuecomment-296272295