### PR TITLE
Add wp cli command for activate master or stable branches

### DIFF
--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -40,7 +40,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 					}
 					return WP_CLI::error( __( 'Unrecognized version', 'jetpack' ) );
 				} else {
-					WP_CLI::error( __( 'Specify a branch to activate', 'jetpack' ) );
+					WP_CLI::error( __( 'Specify master or stable', 'jetpack' ) );
 				}
 			}
 			return WP_CLI::error( __( 'Specify subcommand', 'jetpack' ) );

--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -1,0 +1,52 @@
+<?php
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	/**
+	 * Control your local Jetpack Beta Tester plugin.
+	 */
+	class JetpackBetaCliCommand extends WP_CLI_Command {
+		/**
+		 * Activate a branch version
+		 *
+		 * ## OPTIONS
+		 *
+		 *
+		 * activate master: Get a version of the master branch built every 15 minutes
+		 *
+		 * activate stable: Get the latest stable version of Jetpack
+		 *
+		 * ## EXAMPLES
+		 *
+		 * wp jetpack-beta branch activate master
+		 * wp jetpack-beta branch activate stable
+		 *
+		 */
+		public function branch( $args ) {
+			if ( ! empty( $args ) ) {
+				if ( 'activate' === $args[0] && ! empty( $args[1] ) ) {
+					if ( 'master' === $args[1] ) {
+						$retvalue = Jetpack_Beta::install_and_activate( 'master', 'master' );
+						if ( is_wp_error( $retvalue ) ) {
+							return WP_CLI::error( __( 'Error', 'jetpack' ) . $retvalue->get_error_message() );
+						}
+						return WP_CLI::success( __( 'Jetpack is currently on Bleeding Edge', 'jetpack-beta' ) );
+					}
+					if ( 'stable' === $args[1] ) {
+						$retvalue = Jetpack_Beta::install_and_activate( 'stable', 'stable' );
+						if ( is_wp_error( $retvalue ) ) {
+							return WP_CLI::error( __( 'Error', 'jetpack' ) . $retvalue->get_error_message() );
+						}
+						return WP_CLI::success( __( 'Jetpack is currently on Latest Stable', 'jetpack-beta' ) );
+					}
+					return WP_CLI::error( __( 'Unrecognized version', 'jetpack' ) );
+				} else {
+					WP_CLI::error( __( 'Specify a branch to activate', 'jetpack' ) );
+				}
+			}
+			return WP_CLI::error( __( 'Specify subcommand', 'jetpack' ) );
+		}
+	}
+
+	WP_CLI::add_command( 'jetpack-beta', 'JetpackBetaCliCommand' );
+
+}

--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -1,7 +1,6 @@
 <?php
 
-// To make sure this extention is not available for multisite instalations
-if ( defined( 'WP_CLI' ) && WP_CLI && ! is_multisite() && is_main_site() ) {
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	/**
 	 * Control your local Jetpack Beta Tester plugin.
 	 */
@@ -23,28 +22,38 @@ if ( defined( 'WP_CLI' ) && WP_CLI && ! is_multisite() && is_main_site() ) {
 		 *
 		 */
 		public function branch( $args ) {
-			if ( ! empty( $args ) ) {
-				if ( 'activate' === $args[0] && ! empty( $args[1] ) ) {
-					if ( 'master' === $args[1] ) {
-						$retvalue = Jetpack_Beta::install_and_activate( 'master', 'master' );
-						if ( is_wp_error( $retvalue ) ) {
-							return WP_CLI::error( __( 'Error', 'jetpack' ) . $retvalue->get_error_message() );
-						}
-						return WP_CLI::success( __( 'Jetpack is currently on Bleeding Edge', 'jetpack-beta' ) );
-					}
-					if ( 'stable' === $args[1] ) {
-						$retvalue = Jetpack_Beta::install_and_activate( 'stable', 'stable' );
-						if ( is_wp_error( $retvalue ) ) {
-							return WP_CLI::error( __( 'Error', 'jetpack' ) . $retvalue->get_error_message() );
-						}
-						return WP_CLI::success( __( 'Jetpack is currently on Latest Stable', 'jetpack-beta' ) );
-					}
-					return WP_CLI::error( __( 'Unrecognized version', 'jetpack' ) );
-				} else {
-					WP_CLI::error( __( 'Specify master or stable', 'jetpack' ) );
+
+			$this->validation_checks($args);
+				
+			if ( 'master' === $args[1] ) {
+				$retvalue = Jetpack_Beta::install_and_activate( 'master', 'master' );
+				if ( is_wp_error( $retvalue ) ) {
+					return WP_CLI::error( __( 'Error', 'jetpack' ) . $retvalue->get_error_message() );
 				}
+				return WP_CLI::success( __( 'Jetpack is currently on Bleeding Edge', 'jetpack-beta' ) );
 			}
-			return WP_CLI::error( __( 'Specify subcommand', 'jetpack' ) );
+			if ( 'stable' === $args[1] ) {
+				$retvalue = Jetpack_Beta::install_and_activate( 'stable', 'stable' );
+				if ( is_wp_error( $retvalue ) ) {
+					return WP_CLI::error( __( 'Error', 'jetpack' ) . $retvalue->get_error_message() );
+				}
+				return WP_CLI::success( __( 'Jetpack is currently on Latest Stable', 'jetpack-beta' ) );
+			}
+			return WP_CLI::error( __( 'Unrecognized version', 'jetpack' ) );
+		}
+
+		private function validation_checks($args) {
+			if ( is_multisite() && ! is_main_site() ) {
+				return WP_CLI::error( __( 'Secondary sites in multisite instalations are not supported', 'jetpack' ) );				
+			}
+
+			if ( empty( $args ) ) {
+				return WP_CLI::error( __( 'Specify subcommand', 'jetpack' ) );
+			}
+
+			if ( 'activate' !== $args[0] || empty( $args[1] ) ) {
+				WP_CLI::error( __( 'Passed arguments are not valid. Check usage examples', 'jetpack' ) );				
+			}
 		}
 	}
 

--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -1,6 +1,7 @@
 <?php
 
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
+// To make sure this extention is not available for multisite instalations
+if ( defined( 'WP_CLI' ) && WP_CLI && ! is_multisite() && is_main_site() ) {
 	/**
 	 * Control your local Jetpack Beta Tester plugin.
 	 */

--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -23,7 +23,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		 */
 		public function branch( $args ) {
 
-			$this->validation_checks($args);
+			$this->validation_checks( $args );
 				
 			if ( 'master' === $args[1] ) {
 				$retvalue = Jetpack_Beta::install_and_activate( 'master', 'master' );
@@ -39,7 +39,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				}
 				return WP_CLI::success( __( 'Jetpack is currently on Latest Stable', 'jetpack-beta' ) );
 			}
-			return WP_CLI::error( __( 'Unrecognized version', 'jetpack' ) );
+			return WP_CLI::error( __( 'Unrecognized branch version. ', 'jetpack' ) );
 		}
 
 		private function validation_checks($args) {
@@ -51,12 +51,15 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				return WP_CLI::error( __( 'Specify subcommand', 'jetpack' ) );
 			}
 
-			if ( 'activate' !== $args[0] || empty( $args[1] ) ) {
-				WP_CLI::error( __( 'Passed arguments are not valid. Check usage examples', 'jetpack' ) );				
+			if ( 'activate' !== $args[0] ) {
+				return WP_CLI::error( __( 'Only "activate" subcommand is supported', 'jetpack' ) );				
+			}
+
+			if ( empty( $args[1] ) ) {
+				return WP_CLI::error( __( 'Specify branch name', 'jetpack' ) );				
 			}
 		}
 	}
 
 	WP_CLI::add_command( 'jetpack-beta', 'JetpackBetaCliCommand' );
-
 }

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -650,11 +650,11 @@ class Jetpack_Beta {
 			$creds = request_filesystem_credentials( site_url() . '/wp-admin/', '', false, false, array() );
 			if ( ! WP_Filesystem( $creds ) ) {
 				/* any problems and we exit */
-				return;
+				return new WP_error( 'Filesystem Problem' );
 			}
 			global $wp_filesystem;
 			if ( ! $wp_filesystem ) {
-				return;
+				return new WP_error( '$wp_filesystem is not global' );
 			}
 
 			$working_dir = WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . 'jetpack-pressable-beta';

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -58,6 +58,7 @@ define( 'JETPACK_BETA_REPORT_URL', 'https://jetpack.com/contact-support/beta-gro
 
 
 require_once 'autoupdate-self.php';
+require_once 'class-jetpackbetaclicommand.php';
 add_action( 'init', array( 'Jetpack_Beta_Autoupdate_Self', 'instance' ) );
 
 class Jetpack_Beta {


### PR DESCRIPTION
Fixes #32

Introduces `wp jetpack-beta branch activate master` and `wp jetpack-beta branch activate stable` commands

