### PR TITLE
Make the more info link for PRs open in new tab

### DIFF
--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -243,7 +243,7 @@ class Jetpack_Beta_Admin {
 		$pr         = '';
 		if ( isset( $branch->pr ) && is_int( $branch->pr ) ) {
 			$pr        = sprintf( 'data-pr="%s"', esc_attr( $branch->pr ) );
-			$more_info = sprintf( __( '<a href="%s">more info #%s</a> - ', 'jetpack-beta' ), Jetpack_Beta::get_url( $branch_key, $section ), $branch->pr );
+			$more_info = sprintf( __( '<a target="_blank" rel="external noopener noreferrer" href="%s">more info #%s</a> - ', 'jetpack-beta' ), Jetpack_Beta::get_url( $branch_key, $section ), $branch->pr );
 		}
 
 		$update_time = ( isset( $branch->update_date )


### PR DESCRIPTION
This will help with not losing the search context when clicking on one of the PRs links

#### Changes introduced by this PR

* Makes the `more info` link when listing PRs in the autocomplete, open in a new window. Adds `target="_blank" rel="external noopener noreferrer"` to the link

