### PR TITLE
Admin: Make Topbar node not link to settings if user cannot update_plugins

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -289,7 +289,7 @@ class Jetpack_Beta {
 			'id'    => 'jetpack-beta_admin_bar',
 			'title' => 'Jetpack Beta',
 			'parent' => 'top-secondary',
-			'href'  => self::admin_url()
+			'href'  => current_user_can( 'update_plugins' ) ? self::admin_url() : ''
 		);
 		$wp_admin_bar->add_node( $args );
 


### PR DESCRIPTION
Fixes #30

Currently all users can see the TopBar Node reading "Jetpack Beta" which links to Jetpack Beta settings page.

It's been reported that this does not look as an expected behaviour if you are not an administrator. 

#### Changes introduced by this PR

* Makes the Topbar node not be a link if the user does not have update_plugins capabilities

#### Screenshots

**Before**

![before](https://user-images.githubusercontent.com/746152/32357293-4528cba8-c01a-11e7-9e06-f4c82ce1cc70.gif)

**After**

![after](https://user-images.githubusercontent.com/746152/32357299-4af14d94-c01a-11e7-8c9c-00a422acc62c.gif)
