### PR TITLE
Fix/autoupdates to work again

### DIFF
--- a/autoupdate-self.php
+++ b/autoupdate-self.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Jetpack_Beta_Autoupdate_Self {
 	protected static $_instance = null;
 
+	const TRANSIENT_NAME = 'JETPACK_BETA_LATEST_TAG';
+
 	/**
 	 * Main Instance
 	 */
@@ -34,6 +36,8 @@ class Jetpack_Beta_Autoupdate_Self {
 			'requires'           => '4.7',
 			'tested'             => '4.7'
 		);
+
+
 
 		add_filter( 'pre_set_site_transient_update_plugins', array( $this, 'api_check' ) );
 		add_filter( 'plugins_api', array( $this, 'get_plugin_info' ), 10, 3 );
@@ -132,8 +136,8 @@ class Jetpack_Beta_Autoupdate_Self {
 		if ( ! isset( $transient->no_update ) ) {
 			return $transient;
 		}
-		// Clear our transient
-		delete_site_transient( md5( $this->config['slug'] ) . '_latest_tag' );
+		// get the latest version
+		delete_site_transient( self::TRANSIENT_NAME );
 
 		if ( $this->has_never_version() ) {
 			$response              = new stdClass;

--- a/autoupdate-self.php
+++ b/autoupdate-self.php
@@ -183,14 +183,13 @@ class Jetpack_Beta_Autoupdate_Self {
 	}
 
 	public function auto_update_jetpack_beta( $update, $item ) {
-		if ( 'sure' !== get_option( 'jp_beta_autoupdate') ) {
+		if ( ! Jetpack_Beta::is_set_to_autoupdate() ) {
 			return $update;
 		}
 
 		if ( $item->slug === $this->config['slug'] ) {
 			return true;
-		} else {
-			return $update; // Else, use the normal API response to decide whether to update or not
 		}
+		return $update; // Else, use the normal API response to decide whether to update or not
 	}
 }

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -383,7 +383,7 @@ class Jetpack_Beta_Admin {
 	}
 
 	static function show_toggle_autoupdates() {
-		$autoupdate = (bool) get_option( 'jp_beta_autoupdate' );
+		$autoupdate = (bool) Jetpack_Beta::is_set_to_autoupdate();
 
 		$query = array(
 			'page'          => 'jetpack-beta',

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -45,6 +45,8 @@ class Jetpack_Beta_Admin {
 	}
 
 	static function render() {
+		// Always grab the latest version
+		Jetpack_Beta::get_beta_manifest( true );
 		require_once JPBETA__PLUGIN_DIR . 'admin/main.php';
 	}
 
@@ -86,6 +88,10 @@ class Jetpack_Beta_Admin {
 			$autoupdate = (bool) get_option( 'jp_beta_autoupdate' );
 
 			update_option( 'jp_beta_autoupdate', ! $autoupdate );
+
+			if ( Jetpack_Beta::is_set_to_autoupdate() ) {
+				Jetpack_Beta::maybe_schedule_autoupdate();
+			}
 			wp_safe_redirect( Jetpack_Beta::admin_url() );
 		}
 
@@ -407,7 +413,7 @@ class Jetpack_Beta_Admin {
 		$should_update_dev_version = Jetpack_Beta::should_update_dev_version();
 		$should_update_dev_to_master = Jetpack_Beta::should_update_dev_to_master();
 
-		if ( ! $should_update_dev_to_master
+		if ( ! $should_update_stable_version
 			&& ! $should_update_dev_version
 			&& ! $should_update_dev_to_master ) {
 			return;

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -960,7 +960,7 @@ class Jetpack_Beta {
 			return $errors;
 		}
 
-		if ( $result ) {
+		if ( $result && ! defined( 'JETPACK_BETA_SKIP_EMAIL' ) ) {
 			$admin_email = get_site_option( 'admin_email' );
 			$log = array_map( 'html_entity_decode', $log );
 			$message = implode( "\n", $log );

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 2.0.1
+ * Version: 2.1.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -255,6 +255,8 @@ class Jetpack_Beta {
 			return;
 		}
 
+		Jetpack_Beta::clear_autoupdate_cron();
+		Jetpack_Beta::delete_all_transiants();
 		add_action( 'shutdown', array( __CLASS__, 'switch_active' ) );
 		delete_option( self::$option );
 
@@ -659,6 +661,16 @@ class Jetpack_Beta {
 		return $cache;
 	}
 
+	static function delete_all_transiants() {
+		$prefix = 'jetpack_beta_';
+
+		delete_site_transient( $prefix. 'org_data' );
+		delete_site_transient( $prefix. 'manifest' );
+
+		delete_site_transient( Jetpack_Beta_Autoupdate_Self::TRANSIENT_NAME );
+
+	}
+
 	static function install_and_activate( $branch, $section ) {
 
 		// Clean up previous version of the beta plugin
@@ -878,7 +890,6 @@ class Jetpack_Beta {
 	}
 
 	static function clear_autoupdate_cron() {
-		error_log( 'clear_autoupdate_cron' );
 		wp_clear_scheduled_hook( Jetpack_Beta::$auto_update_cron_hook );
 
 		if ( function_exists( 'wp_unschedule_hook' ) ) { // new in WP 4.9
@@ -887,7 +898,6 @@ class Jetpack_Beta {
 	}
 
 	static function schedule_hourly_autoupdate() {
-		error_log( 'schedule_hourly_autoupdate' );
 		wp_clear_scheduled_hook(  Jetpack_Beta::$auto_update_cron_hook );
 		wp_schedule_event( time(), 'hourly',  Jetpack_Beta::$auto_update_cron_hook );
 	}
@@ -903,9 +913,7 @@ class Jetpack_Beta {
 	}
 
 	static function run_autoupdate() {
-		error_log( 'RAN autoupdate!' );
 		if ( ! Jetpack_Beta::is_set_to_autoupdate() ) {
-			error_log('NO is_set_to_autoupdate' );
 			return;
 		}
 
@@ -930,7 +938,6 @@ class Jetpack_Beta {
 		}
 
 		if ( empty( $plugins ) ) {
-			error_log('NO plugins' );
 			return;
 		}
 
@@ -954,7 +961,6 @@ class Jetpack_Beta {
 		}
 
 		if ( $result ) {
-			error_log('Worked!');
 			$admin_email = get_site_option( 'admin_email' );
 			$log = array_map( 'html_entity_decode', $log );
 			$message = implode( "\n", $log );

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -257,9 +257,12 @@ class Jetpack_Beta {
 
 		Jetpack_Beta::clear_autoupdate_cron();
 		Jetpack_Beta::delete_all_transiants();
-		add_action( 'shutdown', array( __CLASS__, 'switch_active' ) );
+		add_action( 'shutdown', array( __CLASS__, 'switch_active' ), 5 );
+		add_action( 'shutdown', array( __CLASS__, 'remove_dev_plugin' ), 20 );
 		delete_option( self::$option );
+	}
 
+	static function remove_dev_plugin() {
 		if ( is_multisite() ) {
 			return;
 		}

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -893,6 +893,9 @@ class Jetpack_Beta {
 	}
 
 	static function clear_autoupdate_cron() {
+		if ( ! is_main_site() ) {
+			return;
+		}
 		wp_clear_scheduled_hook( Jetpack_Beta::$auto_update_cron_hook );
 
 		if ( function_exists( 'wp_unschedule_hook' ) ) { // new in WP 4.9
@@ -909,6 +912,10 @@ class Jetpack_Beta {
 		if ( ! Jetpack_Beta::is_set_to_autoupdate() ) {
 			return;
 		}
+
+		if ( ! is_main_site() ) {
+			return;
+		}
 		$has_schedule_already = wp_get_schedule( Jetpack_Beta::$auto_update_cron_hook );
 		if ( ! $has_schedule_already ) {
 			Jetpack_Beta::schedule_hourly_autoupdate();
@@ -917,6 +924,10 @@ class Jetpack_Beta {
 
 	static function run_autoupdate() {
 		if ( ! Jetpack_Beta::is_set_to_autoupdate() ) {
+			return;
+		}
+
+		if ( ! is_main_site() ) {
 			return;
 		}
 

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -550,8 +550,7 @@ class Jetpack_Beta {
 			$org_data = self::get_org_data();
 			return $org_data->download_link;
 		}
-
-		$manifest = Jetpack_Beta::get_beta_manifest();
+		$manifest = Jetpack_Beta::get_beta_manifest( true );
 
 		if ( 'master' === $section && isset( $manifest->{$section}->download_url ) ) {
 			return $manifest->{$section}->download_url;
@@ -609,18 +608,18 @@ class Jetpack_Beta {
 		self::replace_active_plugin( JETPACK_DEV_PLUGIN_FILE, JETPACK_PLUGIN_FILE );
 	}
 
-	static function get_beta_manifest() {
-		return self::get_remote_data( JETPACK_BETA_MANIFEST_URL, 'manifest' );
+	static function get_beta_manifest( $force_refresh = false ) {
+		return self::get_remote_data( JETPACK_BETA_MANIFEST_URL, 'manifest', $force_refresh );
 	}
 
 	static function get_org_data() {
 		return self::get_remote_data( JETPACK_ORG_API_URL, 'org_data' );
 	}
 
-	static function get_remote_data( $url, $transient ) {
+	static function get_remote_data( $url, $transient, $bypass = false) {
 		$prefix = 'jetpack_beta_';
 		$cache  = get_site_transient( $prefix . $transient );
-		if ( $cache ) {
+		if ( $cache && ! $bypass ) {
 			return $cache;
 		}
 

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -356,7 +356,9 @@ class Jetpack_Beta {
 			unset( $transient->no_update[ JETPACK_DEV_PLUGIN_FILE ] );
 		} else {
 			unset( $transient->response[ JETPACK_DEV_PLUGIN_FILE ] );
-			$transient->no_update[ JETPACK_DEV_PLUGIN_FILE ] = self::get_jepack_dev_update_response();
+			if ( isset( $transient->no_update ) ) {
+				$transient->no_update[ JETPACK_DEV_PLUGIN_FILE ] = self::get_jepack_dev_update_response();
+			}
 		}
 
 		return $transient;
@@ -635,7 +637,7 @@ class Jetpack_Beta {
 	}
 
 	function auto_update_jetpack_beta( $update, $item ) {
-		if ( 'sure' !== get_option( 'jp_beta_autoupdate' ) ) {
+		if ( ! self::is_set_to_autoupdate() ) {
 			return $update;
 		}
 
@@ -645,9 +647,8 @@ class Jetpack_Beta {
 		);
 		if ( in_array( $item->slug, $plugins ) ) {
 			return true; // Always update plugins in this array
-		} else {
-			return $update; // Else, use the normal API response to decide whether to update or not
 		}
+		return $update; // Else, use the normal API response to decide whether to update or not
 	}
 
 	static function install_and_activate( $branch, $section ) {
@@ -847,7 +848,11 @@ class Jetpack_Beta {
 		         && $org_data->version !== $plugin_data['Version'] );
 	}
 
-
+	/**
+	 * Here we are checking if the DEV branch that we are currenly on is not something that is available in the manifest
+	 * Meaning that the DEV branch was merged into master and so we need to update it.
+	 * @return bool
+	 */
 	static function should_update_dev_to_master() {
 		list( $branch, $section ) = self::get_branch_and_section_dev();
 
@@ -856,6 +861,10 @@ class Jetpack_Beta {
 		}
 		$manifest = self::get_beta_manifest();
 		return ! isset( $manifest->{$section}->{$branch} );
+	}
+
+	static function is_set_to_autoupdate() {
+		return (bool) get_option( 'jp_beta_autoupdate', false );
 	}
 }
 


### PR DESCRIPTION
Fixes #36
Fixes #39 

Currently autoupdates do not work as expected. 

To test:
- Update Jetpack Beta to this PR. 
Set the version number to 2.0.2 this should trigger an update to the Jetpack beta tester plugin. 
The updates happen via cron and should happen at least every 1 hour. 

- If you are running the Bleeding Edge. You should see your version update as new stuff gets pushed to the master PR. 

- If you are running a PR you should see updates happen when new stuff gets merged into the Jetpack PR. As well as when the PR gets merged into master. 

On every successful auto update an email will to the admin_user. 
emails can be turned off by adding a constant `define( 'JETPACK_BETA_SKIP_EMAIL', true );`





