### PR TITLE
Don't update the jetpack plugin if the build server errors.

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -1091,7 +1091,7 @@ class Jetpack_Beta {
 	static function check_for_main_file( $source, $remote_source ) {
 		if ( $source === $remote_source . '/jetpack-dev/' ) {
 			if ( ! file_exists( $source. 'jetpack.php' ) ) {
-				return new WP_Error( 'plugin_file_does_not_exits', __( 'Main Plugin File does not exist', 'jetpack-beta' ) );
+				return new WP_Error( 'plugin_file_does_not_exist', __( 'Main Plugin File does not exist', 'jetpack-beta' ) );
 			}
 		}
 

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -990,6 +990,8 @@ class Jetpack_Beta {
 			! Jetpack_Beta::is_on_stable() &&
 			( Jetpack_Beta::should_update_dev_to_master() || Jetpack_Beta::should_update_dev_version() )
 		) {
+			add_filter( 'upgrader_source_selection', array( 'Jetpack_Beta', 'check_for_main_file' ), 10, 2 );
+
 			// If response is false, don't alter the transient
 			$plugins[] = JETPACK_DEV_PLUGIN_FILE;
 		}
@@ -1077,6 +1079,23 @@ class Jetpack_Beta {
 			wp_mail( $admin_email, $subject, $message );
 
 		}
+	}
+
+	/**
+	 * This checks intends to fix errors in our build server when jetpack
+	 * @param $source
+	 * @param $remote_source
+	 *
+	 * @return WP_Error
+	 */
+	static function check_for_main_file( $source, $remote_source ) {
+		if ( $source === $remote_source . '/jetpack-dev/' ) {
+			if ( ! file_exists( $source. 'jetpack.php' ) ) {
+				return new WP_Error( 'plugin_file_does_not_exits', __( 'Main Plugin File does not exist', 'jetpack-beta' ) );
+			}
+		}
+
+		return $source;
 	}
 }
 

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -1093,6 +1093,12 @@ class Jetpack_Beta {
 			if ( ! file_exists( $source. 'jetpack.php' ) ) {
 				return new WP_Error( 'plugin_file_does_not_exist', __( 'Main Plugin File does not exist', 'jetpack-beta' ) );
 			}
+			if ( ! file_exists( $source. '_inc/build/static.html' ) ) {
+				return new WP_Error( 'static_admin_page_does_not_exist', __( 'Static Admin Page File does not exist', 'jetpack-beta' ) );
+			}
+			if ( ! file_exists( $source. '_inc/build/admin.js' ) ) {
+				return new WP_Error( 'admin_page_does_not_exist', __( 'Admin Page File does not exist', 'jetpack-beta' ) );
+			}
 		}
 
 		return $source;


### PR DESCRIPTION
Add a check to make sure that at least the main jetpack.php file is present before procceding with the update of the jetpack plugin.


#### To test
* Change the code in the new function to always thow the error. Not just when the file is not there. 
* change the file version of the master branch so that it needs an update. I did this using the wp-admin plugin editor. 
* using wp shell 
    * run `Jetpack_Beta::run_autoupdate();` 
    * Notice that the plugin doesn't update. 
    * You should get no email. ( Do we want that ?)
