### PR TITLE
Make it possible to install RC branches

### DIFF
--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -29,13 +29,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 			if ( 'list' === $args[0] ) {
 				return $this->branches_list();
-			}
-				
-			if ( 'master' === $args[1] ) {
-				return $this->install_jetpack( 'master', 'master' );
-			} elseif ( 'stable' === $args[1] ) {
-				return $this->install_jetpack( 'stable', 'stable' );
-			} else {
+      }
+      
+      $branches = array('master', 'stable', 'rc');
+
+      if (in_array($args[1], $branches)) {
+				return $this->install_jetpack( $args[1], $args[1] );
+      } else {
 				$branch_name = str_replace( '/', '_', $args[1] ); 
 				$url = Jetpack_Beta::get_install_url( $branch_name, 'pr' );
 				if ( $url === null ) {

--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -31,9 +31,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 				return $this->branches_list();
 			}
 			
-			$branches = array('master', 'stable', 'rc');
+			$branches = array( 'master', 'stable', 'rc' );
 
-			if (in_array($args[1], $branches)) {
+			if ( in_array( $args[1], $branches)) {
 				return $this->install_jetpack( $args[1], $args[1] );
 			} else {
 				$branch_name = str_replace( '/', '_', $args[1] ); 

--- a/class-jetpackbetaclicommand.php
+++ b/class-jetpackbetaclicommand.php
@@ -29,13 +29,13 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 			if ( 'list' === $args[0] ) {
 				return $this->branches_list();
-      }
-      
-      $branches = array('master', 'stable', 'rc');
+			}
+			
+			$branches = array('master', 'stable', 'rc');
 
-      if (in_array($args[1], $branches)) {
+			if (in_array($args[1], $branches)) {
 				return $this->install_jetpack( $args[1], $args[1] );
-      } else {
+			} else {
 				$branch_name = str_replace( '/', '_', $args[1] ); 
 				$url = Jetpack_Beta::get_install_url( $branch_name, 'pr' );
 				if ( $url === null ) {

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 2.1.1
+ * Version: 2.2.0
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later


### PR DESCRIPTION
Right now it is not possible to install RC branches via cli command. This PR address this issue

To test: run `$wp jetpack-beta branch activate rc`
Make sure RC branch activated in Jetpack-beta plugin
