### PR TITLE
Add email notifications toggle

### DIFF
--- a/admin/admin.css
+++ b/admin/admin.css
@@ -360,6 +360,7 @@ html {
 .form-toggle__label {
     text-decoration: none;
     color: #124964;
+    margin-left: 10px;
 }
 .form-toggle__label:focus {
     -webkit-box-shadow: none;

--- a/admin/main.php
+++ b/admin/main.php
@@ -25,7 +25,8 @@
 					</div>
 				</span>
 				<span class="dops-foldable-card__secondary">
-						<?php Jetpack_Beta_Admin::show_toggle_autoupdates(); ?>
+					<?php Jetpack_Beta_Admin::show_toggle_emails(); ?>
+					<?php Jetpack_Beta_Admin::show_toggle_autoupdates(); ?>
 				</span>
 			</div>
 			<div class="dops-foldable-card__content">

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -70,7 +70,6 @@ class Jetpack_Beta_Admin {
 			$section = esc_html( $_GET['section'] );
 
 			Jetpack_Beta::install_and_activate( $branch, $section );
-			wp_safe_redirect( Jetpack_Beta::admin_url() );
 		}
 
 		// Update to the latest version
@@ -79,22 +78,33 @@ class Jetpack_Beta_Admin {
 			$section = esc_html( $_GET['section'] );
 
 			Jetpack_Beta::update_plugin( $branch, $section );
-			wp_safe_redirect( Jetpack_Beta::admin_url() );
 		}
 
 		// Toggle autoupdates
-		if ( wp_verify_nonce( $_GET['_nonce'], 'enable_autoupdates' ) && isset( $_GET['_action'] ) && 'toggle_enable_autoupdates' ==  $_GET['_action'] ) {
-
-			$autoupdate = (bool) get_option( 'jp_beta_autoupdate' );
-
-			update_option( 'jp_beta_autoupdate', ! $autoupdate );
+		if ( self::is_toggle_action( 'autoupdates' ) ) {
+			$autoupdate = (bool) Jetpack_Beta::is_set_to_autoupdate() ;
+			update_option( 'jp_beta_autoupdate',(int) ! $autoupdate );
 
 			if ( Jetpack_Beta::is_set_to_autoupdate() ) {
 				Jetpack_Beta::maybe_schedule_autoupdate();
 			}
-			wp_safe_redirect( Jetpack_Beta::admin_url() );
 		}
 
+		// Toggle email notifications
+		if ( self::is_toggle_action( 'email_notifications' ) ) {
+			$enable_email_notifications = (bool) Jetpack_Beta::is_set_to_email_notifications();
+			update_option( 'jp_beta_email_notifications', (int) ! $enable_email_notifications );
+		}
+		wp_safe_redirect( Jetpack_Beta::admin_url() );
+	}
+
+	static function is_toggle_action( $option ) {
+		return (
+			isset( $_GET['_nonce'] ) &&
+			wp_verify_nonce( $_GET['_nonce'], 'enable_' .$option ) &&
+			isset( $_GET['_action'] ) &&
+			'toggle_enable_' . $option === $_GET[ '_action' ]
+		);
 	}
 
 	static function render_banner() {
@@ -390,17 +400,28 @@ class Jetpack_Beta_Admin {
 
 	static function show_toggle_autoupdates() {
 		$autoupdate = (bool) Jetpack_Beta::is_set_to_autoupdate();
+		self::show_toggle( __( 'Autoupdates', 'jetpack-beta' ), 'autoupdates', $autoupdate );
+	}
 
+	static function show_toggle_emails() {
+		if ( ! Jetpack_Beta::is_set_to_autoupdate() || defined( 'JETPACK_BETA_SKIP_EMAIL' ) ) {
+			return;
+		}
+		$email_notification = (bool) Jetpack_Beta::is_set_to_email_notifications();
+		self::show_toggle( __( 'Email Notifications', 'jetpack-beta' ), 'email_notifications', $email_notification );
+	}
+
+	static function show_toggle( $name, $option, $value ) {
 		$query = array(
 			'page'          => 'jetpack-beta',
-			'_action'       => 'toggle_enable_autoupdates',
-			'_nonce'        => wp_create_nonce( 'enable_autoupdates' ),
+			'_action'       => 'toggle_enable_' . $option,
+			'_nonce'        => wp_create_nonce( 'enable_' . $option ),
 		);
 
 		?>
-		<a href="<?php echo esc_url( Jetpack_Beta::admin_url( '?' . build_query( $query ) ) ); ?>" class="form-toggle__label <?php echo ( $autoupdate ? 'is-active' : '' ); ?>"  >
-			<span class="form-toggle-explanation" ><?php _e( 'Autoupdates', 'jetpack-beta' ); ?></span>
-			<span class="form-toggle__switch"  tabindex="0" ></span>
+		<a href="<?php echo esc_url( Jetpack_Beta::admin_url( '?' . build_query( $query ) ) ); ?>" class="form-toggle__label <?php echo ( $value ? 'is-active' : '' ); ?>"  >
+			<span class="form-toggle-explanation" ><?php esc_html_e( $name ); ?></span>
+			<span class="form-toggle__switch" tabindex="0" ></span>
 			<span class="form-toggle__label-content" >
 			</span>
 		</a>

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -82,8 +82,8 @@ class Jetpack_Beta_Admin {
 
 		// Toggle autoupdates
 		if ( self::is_toggle_action( 'autoupdates' ) ) {
-			$autoupdate = (bool) Jetpack_Beta::is_set_to_autoupdate() ;
-			update_option( 'jp_beta_autoupdate',(int) ! $autoupdate );
+			$autoupdate = (bool) Jetpack_Beta::is_set_to_autoupdate();
+			update_option( 'jp_beta_autoupdate', (int) ! $autoupdate );
 
 			if ( Jetpack_Beta::is_set_to_autoupdate() ) {
 				Jetpack_Beta::maybe_schedule_autoupdate();
@@ -101,9 +101,9 @@ class Jetpack_Beta_Admin {
 	static function is_toggle_action( $option ) {
 		return (
 			isset( $_GET['_nonce'] ) &&
-			wp_verify_nonce( $_GET['_nonce'], 'enable_' .$option ) &&
+			wp_verify_nonce( $_GET['_nonce'], 'enable_' . $option ) &&
 			isset( $_GET['_action'] ) &&
-			'toggle_enable_' . $option === $_GET[ '_action' ]
+			'toggle_enable_' . $option === $_GET['_action']
 		);
 	}
 

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -860,7 +860,6 @@ class Jetpack_Beta {
 			return false;
 		}
 
-
 		$updates = get_site_transient( 'update_plugins' );
 
 		if ( isset( $updates->response, $updates->response[ JETPACK_PLUGIN_FILE ] ) ) {
@@ -890,6 +889,10 @@ class Jetpack_Beta {
 
 	static function is_set_to_autoupdate() {
 		return get_option( 'jp_beta_autoupdate', false );
+	}
+
+	static function is_set_to_email_notifications() {
+		return get_option( 'jp_beta_email_notifications', true );
 	}
 
 	static function clear_autoupdate_cron() {
@@ -1021,7 +1024,7 @@ class Jetpack_Beta {
 			return $errors;
 		}
 
-		if ( $result && ! defined( 'JETPACK_BETA_SKIP_EMAIL' ) ) {
+		if ( $result && ! defined( 'JETPACK_BETA_SKIP_EMAIL' ) && self::is_set_to_email_notifications() ) {
 			$admin_email = get_site_option( 'admin_email' );
 
 			if ( empty( $admin_email ) ) {


### PR DESCRIPTION
Fixes #53 
Add a toggle that looks like 

![screen shot 2018-03-14 at 10 08 46 am](https://user-images.githubusercontent.com/115071/37418535-b61c3eaa-276f-11e8-930a-47ad2f051332.png)


The toggle doesn't show up if the autoupdates toggle is disabled or the constant defined. Since the toggle in those cases wouldn't do anything anyways.

This is what it looks like.
![screen shot 2018-03-14 at 10 10 15 am](https://user-images.githubusercontent.com/115071/37418685-09e270cc-2770-11e8-9da7-99a7fcf0580c.png)


cc: @rickybanister and @oskosk 