### PR TITLE
Jetpack Beta: Report correct Jetpack version to Calypso

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -180,6 +180,8 @@ class Jetpack_Beta {
 	public function update_all_plugins( $plugins ) {
 		// WP.com requests away show regular plugin
 		if ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) {
+			//Ensure that Jetpack reports the version it's using on account of the Jetpack Beta plugin to Calypso
+			$plugins[ JETPACK_PLUGIN_FILE ]['Version'] = $plugins[ JETPACK_DEV_PLUGIN_FILE ]['Version'];
 			unset( $plugins[ JETPACK_DEV_PLUGIN_FILE ] );
 			return $plugins;
 		}

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -181,7 +181,9 @@ class Jetpack_Beta {
 		// WP.com requests away show regular plugin
 		if ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST ) {
 			//Ensure that Jetpack reports the version it's using on account of the Jetpack Beta plugin to Calypso
-			$plugins[ JETPACK_PLUGIN_FILE ]['Version'] = $plugins[ JETPACK_DEV_PLUGIN_FILE ]['Version'];
+			if ( is_plugin_active( JETPACK_DEV_PLUGIN_FILE ) ) {
+				$plugins[ JETPACK_PLUGIN_FILE ]['Version'] = $plugins[ JETPACK_DEV_PLUGIN_FILE ]['Version'];
+			}
 			unset( $plugins[ JETPACK_DEV_PLUGIN_FILE ] );
 			return $plugins;
 		}


### PR DESCRIPTION
This PR ensures that the version of Jetpack in use on account of the Jetpack Beta plugin is reported properly to/reflected in Calypso.

To test, apply this branch, ensure that the stable, release candidate, bleeding edge, and beta plugin deactivated versions all match in Calypso.