### PR TITLE
Fix fatal error in some cases

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 2.3
+ * Version: 2.3.1
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -537,7 +537,10 @@ class Jetpack_Beta {
 			return $manifest->{$section}->version;
 		}
 
-		if ( isset( $manifest->{$section}->{$branch}->version ) ) {
+		if ( isset( $manifest->{$section} ) &&
+		     isset( $manifest->{$section}->{$branch} ) &&
+		     isset( $manifest->{$section}->{$branch}->version )
+		   ) {
 			return $manifest->{$section}->{$branch}->version;
 		}
 		return 0;


### PR DESCRIPTION
It should fix fatals like this: `[02-Nov-2018 11:14:04] PHP Fatal error:  Cannot access empty property in /home/jptest/public_html/wp-content/plugins/jetpack-beta-master/jetpack-beta.php on line 540`