### PR TITLE
Remove unused constant JETPACK_RC_API_URL

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -44,7 +44,6 @@ define( 'JPBETA_DEFAULT_BRANCH', 'rc_only' );
 
 define( 'JETPACK_BETA_MANIFEST_URL', 'https://betadownload.jetpack.me/jetpack-branches.json' );
 define( 'JETPACK_ORG_API_URL', 'https://api.wordpress.org/plugins/info/1.0/jetpack.json' );
-define( 'JETPACK_RC_API_URL', 'https://betadownload.jetpack.me/rc/rc.json' );
 define( 'JETPACK_GITHUB_API_URL', 'https://api.github.com/repos/Automattic/Jetpack/' );
 define( 'JETPACK_GITHUB_URL', 'https://github.com/Automattic/jetpack' );
 define( 'JETPACK_DEFAULT_URL', 'https://jetpack.com' );


### PR DESCRIPTION
The constant `JETPACK_RC_API_URL` was once defined in 9388ee89f3cea86dad98e35f1975b870e9288f77 and never used in real life