### PR TITLE
Add/to-test section in autoupdate email

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -1104,6 +1104,10 @@ class Jetpack_Beta {
 		$message .= ' - ' . implode( "\n - ", $log );
 		$message .= "\n\n";
 
+		// Adds To test section. for PR's it's a PR description, for master/RC - it's a to_test.md file contents.
+		$message .= Jetpack_Beta_Admin::to_test_content();
+		$message .= "\n\n";
+
 		wp_mail( $admin_email, $subject, $message );
 	}
 

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -1033,64 +1033,78 @@ class Jetpack_Beta {
 		}
 
 		if ( $result && ! defined( 'JETPACK_BETA_SKIP_EMAIL' ) && self::is_set_to_email_notifications() ) {
-			$admin_email = get_site_option( 'admin_email' );
-
-			if ( empty( $admin_email ) ) {
-				return;
-			}
-			// Calling empty() on a function return value crashes in PHP < 5.5.
-			// Thus we assign the return value explicitly and then check with empty().
-			$bloginfo_name = get_bloginfo( 'name' );
-			$site_title = ! empty( $bloginfo_name ) ? get_bloginfo( 'name' ) : get_site_url();
-			$what_updated = 'Jetpack Beta Tester Plugin';
-			$subject = sprintf( __( '[%s] Autoupdated Jetpack Beta Tester', 'jetpack-beta' ), $site_title );
-			if ( in_array( JETPACK_DEV_PLUGIN_FILE, $plugins ) ) {
-				$subject = sprintf(  __( '[%s] Autoupdated Jetpack %s ', 'jetpack-beta' ),
-					$site_title,
-					Jetpack_Beta::get_jetpack_plugin_pretty_version()
-				);
-
-				$what_updated = sprintf( __( 'Jetpack %s (%s)', 'jetpack-beta' ),
-					Jetpack_Beta::get_jetpack_plugin_pretty_version(),
-					Jetpack_Beta::get_jetpack_plugin_version()
-				);
-
-				if ( count( $plugins ) > 1 ) {
-					$subject = sprintf( __( '[%s] Autoupdated Jetpack %s and the Jetpack Beta Tester', 'jetpack-beta' ),
-						$site_title,
-						Jetpack_Beta::get_jetpack_plugin_pretty_version()
-					);
-
-					$what_updated = sprintf( __(  'Jetpack %s (%s) and the Jetpack Beta Tester', 'jetpack-beta' ),
-						Jetpack_Beta::get_jetpack_plugin_pretty_version(),
-						Jetpack_Beta::get_jetpack_plugin_version()
-					);
-				}
-			}
-
-			$message  = sprintf(
-				__( 'Howdy! Your site at %1$s has autoupdated %2$s.', 'jetpack-beta' ),
-				home_url(),
-				$what_updated
-			);
-			$message .= "\n\n";
-
-			if ( $what_changed = Jetpack_Beta::what_changed() ) {
-				$message .= __( 'What changed?', 'jetpack-beta' );
-				$message .= strip_tags( $what_changed );
-			}
-
-			$message  .= __( 'During the autoupdate the following happened:', 'jetpack-beta' );
-			$message .= "\n\n";
-			// Can only reference the About screen if their update was successful.
-			$log = array_map( 'html_entity_decode', $log );
-			$message .= ' - ' . implode( "\n - ", $log );
-
-			$message .= "\n\n";
-
-			wp_mail( $admin_email, $subject, $message );
-
+			self::send_autoupdate_email( $plugins, $log );
 		}
+	}
+
+	/**
+	 * Builds and sends an email about succesfull plugin autoupdate
+	 *
+	 * @param Array  $plugins List of plugins that were updated.
+	 * @param String $log upgrade message from core's plugin upgrader.
+	 */
+	private static function send_autoupdate_email( $plugins, $log ) {
+		$admin_email = get_site_option( 'admin_email' );
+
+		if ( empty( $admin_email ) ) {
+			return;
+		}
+		// Calling empty() on a function return value crashes in PHP < 5.5.
+		// Thus we assign the return value explicitly and then check with empty().
+		$bloginfo_name = get_bloginfo( 'name' );
+		$site_title    = ! empty( $bloginfo_name ) ? get_bloginfo( 'name' ) : get_site_url();
+		$what_updated  = 'Jetpack Beta Tester Plugin';
+		$subject       = sprintf( __( '[%s] Autoupdated Jetpack Beta Tester', 'jetpack-beta' ), $site_title );
+
+		if ( in_array( JETPACK_DEV_PLUGIN_FILE, $plugins, true ) ) {
+			$subject = sprintf(
+				__( '[%s] Autoupdated Jetpack %s ', 'jetpack-beta' ),
+				$site_title,
+				self::get_jetpack_plugin_pretty_version()
+			);
+
+			$what_updated = sprintf(
+				__( 'Jetpack %s (%s)', 'jetpack-beta' ),
+				self::get_jetpack_plugin_pretty_version(),
+				self::get_jetpack_plugin_version()
+			);
+
+			if ( count( $plugins ) > 1 ) {
+				$subject = sprintf(
+					__( '[%s] Autoupdated Jetpack %s and the Jetpack Beta Tester', 'jetpack-beta' ),
+					$site_title,
+					self::get_jetpack_plugin_pretty_version()
+				);
+
+				$what_updated = sprintf(
+					__( 'Jetpack %s (%s) and the Jetpack Beta Tester', 'jetpack-beta' ),
+					self::get_jetpack_plugin_pretty_version(),
+					self::get_jetpack_plugin_version()
+				);
+			}
+		}
+
+		$message  = sprintf(
+			__( 'Howdy! Your site at %1$s has autoupdated %2$s.', 'jetpack-beta' ),
+			home_url(),
+			$what_updated
+		);
+		$message .= "\n\n";
+
+		$what_changed = self::what_changed();
+		if ( $what_changed ) {
+			$message .= __( 'What changed?', 'jetpack-beta' );
+			$message .= wp_strip_all_tags( $what_changed );
+		}
+
+		$message .= __( 'During the autoupdate the following happened:', 'jetpack-beta' );
+		$message .= "\n\n";
+		// Can only reference the About screen if their update was successful.
+		$log      = array_map( 'html_entity_decode', $log );
+		$message .= ' - ' . implode( "\n - ", $log );
+		$message .= "\n\n";
+
+		wp_mail( $admin_email, $subject, $message );
 	}
 
 	/**

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -1049,6 +1049,10 @@ class Jetpack_Beta {
 		if ( empty( $admin_email ) ) {
 			return;
 		}
+
+		// In case the code is called in a scope different from wp-admin.
+		require_once JPBETA__PLUGIN_DIR . 'jetpack-beta-admin.php';
+
 		// Calling empty() on a function return value crashes in PHP < 5.5.
 		// Thus we assign the return value explicitly and then check with empty().
 		$bloginfo_name = get_bloginfo( 'name' );


### PR DESCRIPTION
Fixes: #76 

Adds a "To Test" section into an autoupdate email. 

`Jetpack_Beta_Admin::to_test_content()` get's the local `to_test.md` contents for `master` or `rc` branches. For `pr` it returns the PR description.

#### Testing instructions
-  I don't know :) 
- I was thinking to split email code into `builder` and `sender` and write some unit tests for the builder part, but not sure it worth it 🤷‍♂
- basically, the to_test contents should be equal to what you see on `wp-admin/admin.php?page=jetpack-beta` under "To test" section. 

Here is the example of `$sugject` & `message` variables dumps:

```
Array
(
    [0] => [Test Blog] Autoupdated Jetpack Release Candidate
    [1] => Howdy! Your site at http://example.org has autoupdated Jetpack Release Candidate (7.5.3-117-g0119d2e).

During the autoupdate the following happened:

 -

<p>## 7.5</p>
<p>### Dashboard</p>
<p>This release introduces many small changes in the Jetpack dashboard. We&#8217;ve updating the wording that describes several features, we&#8217;ve removed a feature that would offer you to activate a list of recommended features upon connecting your site to WordPress.com, we&#8217;ve removed some of the buttons offering you to upgrade to a Paid plan on the &#8220;At a Glance&#8221; view, we&#8217;ve tried to describe each plan a little better, and more.</p>
<p>Do not hesitate to browse through all main Dashboard Pages (&#8220;At a Glance&#8221;, &#8220;My Plan&#8221;, &#8220;Plans&#8221;, &#8220;Settings&#8221;). Check the phrases describing each feature, and let us know if you spot any typo or anything odd.</p>
<p>### Magic Links</p>
<p>This feature introduces a new option in the Jetpack dashboard. If you use one of the mobile apps, you&#8217;ll now be able to send an email to yourself, from the Jetpack dashboard, with a magic link that will allow you to log in to the mobile app in one click. We would invite you to test two scenarios:</p>
<p>**Testing the error case:**</p>
<p>1. Ensure that Jetpack site is connected to a test account that **is** an Automattician account<br />
2. Go to Jetpack > Dashboard<br />
3. Click Connect to mobile WordPress app link. That link appears in the Connection area.<br />
4. Ensure modal pops up<br />
5. Click Send Link button<br />
6. Ensure that an error message occurs (this is due to you being connected to an Automattician account)<br />
7. Disconnect site</p>
<p>**Testing the success case:**</p>
<p>1. Reconnect site to a WordPress.com test user that **is not** an Automattician account<br />
2. Click Connect to mobile WordPress app link<br />
3. Ensure modal pops up<br />
4. Click Send Link button<br />
5. Ensure that you receive email with magic link</p>
<p>### VideoPress</p>
<p>We&#8217;ve made some changes to how video thumbnails were saved after uploading a video using Jetpack Videos, aka VideoPress. To test this, try the following:</p>
<p>1. Start with a site including a plan that supports Jetpack Videos<br />
2. Go to Jetpack > Settings and enable the Video toggle.<br />
3. Go to this page and select your site: https://wordpress.com/media/<br />
4. Upload a video. After uploading, you may have to wait a few minutes for the video to be processed.<br />
5. Refresh the page, and you should see a video thumbnail appear below the video icon for that video.<br />
6. Try setting a different Video thumbnail there.<br />
7. Go back to your site and enable the Image CDN option under Jetpack > Settings > Performance.<br />
8. Add the following code snippet (here is how you can do it](https://jetpack.com/support/adding-code-snippets/)):<br />
&#8220;`php<br />
add_filter(&#8216;jetpack_photon_pre_args&#8217;, &#8216;jetpackme_custom_photon_compression&#8217; );<br />
function jetpackme_custom_photon_compression( $args ) {<br />
	$args[&#8216;quality&#8217;] = 80;<br />
	$args[&#8216;strip&#8217;] = &#8216;all&#8217;;<br />
	return $args;<br />
}<br />
&#8220;`<br />
9. Repeat steps 3 to 5, make sure video thumbnails appear nicely for existing and new videos.</p>
<p>### Others</p>
<p>&#8211; If you have the opportunity to test in an older browser like IE11, please do so. You may catch some interesting bugs!<br />
&#8211; **At any point during your testing, remember to [check your browser&#8217;s JavaScript console](https://codex.wordpress.org/Using_Your_Browser_to_Diagnose_JavaScript_Errors#Step_3:_Diagnosis) and see if there are any errors reported by Jetpack there.**<br />
&#8211; Use &#8220;Debug Bar&#8221; or &#8220;Query Monitor&#8221; to help make PHP notices and warnings more noticible and report anything you see.</p>
<p>**Thank you for all your help!**</p>

)
```
