### PR TITLE
Tracking: add tracking on the toggles, bug report submissions, and branch activation buttons

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,132 +1,136 @@
-(function () {
-    // Elements
-    var sections = document.getElementById('section-pr').querySelectorAll('.branch-card');
-    var search_input = document.getElementById('search-component');
-    var search_close_link = document.getElementById('search-component-close');
-    var activate_links = document.querySelectorAll('.activate-branch');
-    var toggle_links = document.querySelectorAll('.form-toggle__label');
+(function() {
+	// Elements
+	var sections = document.getElementById('section-pr').querySelectorAll('.branch-card');
+	var search_input = document.getElementById('search-component');
+	var search_close_link = document.getElementById('search-component-close');
+	var activate_links = document.querySelectorAll('.activate-branch');
+	var toggle_links = document.querySelectorAll('.form-toggle__label');
 
+	var section_index = []; //
+	var each = Array.prototype.forEach;
+	var clicked_activate = false;
+	var clicked_toggle = false;
 
-    var section_index = []; //
-    var each = Array.prototype.forEach;
-    var clicked_activate = false;
-    var clicked_toggle = false;
+	each.call(sections, function(element, index) {
+		hide(element);
+		element.querySelector('.activate-branch').setAttribute('data-index', index);
+		section_index[index] = {
+			header: element.querySelector('.branch-card-header').textContent,
+			pr: element.getAttribute('data-pr'),
+			element: element,
+		};
+	});
 
-    each.call(sections, function (element, index) {
-        hide( element );
-        element.querySelector('.activate-branch').setAttribute('data-index', index);
-        section_index[index] = {
-            header: element.querySelector('.branch-card-header').textContent,
-            pr: element.getAttribute('data-pr'),
-            element: element
-        }
-    });
+	// Search input
+	search_input.addEventListener('keyup', function(event) {
+		var search_for = pr_to_header(search_input.value);
 
-    // Search input
-    search_input.addEventListener("keyup", function (event) {
-        var search_for = pr_to_header(search_input.value);
+		if (!search_for) {
+			hide(search_close_link);
+			hide_section();
+			return;
+		}
 
-        if (!search_for) {
-            hide( search_close_link );
-            hide_section();
-            return;
-        }
+		show(search_close_link);
+		section_index.forEach(show_found_branches.bind(this, search_for));
+	});
 
-        show( search_close_link );
-        section_index.forEach( show_found_branches.bind( this, search_for ) );
-    });
+	function show_found_branches(search_for, branch) {
+		var element = branch.element;
+		var header_text = parseInt(search_for) > 0 ? branch.pr.toString() : branch.header;
 
-    function show_found_branches(search_for, branch) {
-        var element = branch.element;
-        var header_text = ( parseInt(search_for) > 0 ) ? branch.pr.toString() : branch.header;
+		var found_position = header_text.indexOf(search_for);
+		if (-1 === found_position) {
+			hide(element);
+			return;
+		}
 
-        var found_position = header_text.indexOf(search_for);
-        if (-1 === found_position) {
-            hide( element );
-            return;
-        }
+		element.querySelector('.branch-card-header').innerHTML = highlight_word(
+			search_for,
+			header_text
+		);
+		show(element);
+	}
 
-        element.querySelector('.branch-card-header').innerHTML = highlight_word(search_for, header_text);
-        show( element );
-    }
+	// Search close link
+	hide(search_close_link);
+	search_close_link.addEventListener('click', function(event) {
+		hide_section();
+		hide(search_close_link);
+		search_input.value = '';
+		event.preventDefault();
+	});
 
-    // Search close link
-    hide( search_close_link );
-    search_close_link.addEventListener('click', function (event) {
-        hide_section();
-        hide( search_close_link );
-        search_input.value = '';
-        event.preventDefault();
-    });
+	// Activate Links
+	each.call(activate_links, function(element, index) {
+		element.addEventListener('click', activate_link_click.bind(this, element));
+	});
 
-    // Activate Links
-    each.call(activate_links, function (element, index) {
-        element.addEventListener('click', activate_link_click.bind( this, element ) );
-    });
+	function activate_link_click(element, event) {
+		if (clicked_activate) {
+			return;
+		}
+		if (element.textContent == JetpackBeta.activate) {
+			element.parentNode.textContent = JetpackBeta.activating;
+		} else {
+			element.parentNode.textContent = JetpackBeta.updating;
+		}
 
-    function activate_link_click( element, event ) {
-        if ( clicked_activate ) {
-           return;
-        }
-        if ( element.textContent == JetpackBeta.activate ) {
-            element.parentNode.textContent = JetpackBeta.activating;
-        } else {
-            element.parentNode.textContent = JetpackBeta.updating;
-        }
+		var index = parseInt(element.getAttribute('data-index'));
 
-        var index = parseInt( element.getAttribute('data-index') );
+		sections = Array.prototype.filter.call(sections, function(element, i) {
+			return index === i ? false : true;
+		});
+		disable_activete_branch_links();
+		clicked_activate = true;
+	}
 
-        sections = Array.prototype.filter.call( sections, function( element, i ) {
-            return (index === i ? false: true );
-        } );
-        disable_activete_branch_links();
-        clicked_activate = true;
-    }
+	function disable_activete_branch_links() {
+		each.call(activate_links, function(element, index) {
+			element.addEventListener('click', function(event) {
+				event.preventDefault();
+			});
+			element.removeEventListener('click', activate_link_click.bind(this, element));
+			element.classList.add('is-disabled');
+		});
+	}
 
-    function disable_activete_branch_links() {
-        each.call(activate_links, function (element, index) {
-            element.addEventListener('click', function (event) {
-                event.preventDefault();
-            } );
-            element.removeEventListener( 'click', activate_link_click.bind( this, element ) );
-            element.classList.add('is-disabled');
-        })
-    }
+	// Toggle Links
+	each.call(toggle_links, function(element, index) {
+		element.addEventListener('click', toggle_link_click.bind(this, element));
+	});
+	function toggle_link_click(element, event) {
+		if (clicked_toggle) {
+			return;
+		}
+		clicked_toggle = true;
+		element.classList.toggle('is-active');
+	}
 
-    // Toggle Links
-    each.call( toggle_links, function( element, index ) {
-        element.addEventListener('click', toggle_link_click.bind( this, element ) );
+	// Helper functions
+	function pr_to_header(search) {
+		return search
+			.replace('/', ' / ')
+			.replace(new RegExp('\\-', 'g'), ' ')
+			.replace(/  +/g, ' ')
+			.toLowerCase();
+	}
 
+	function highlight_word(word, phrase) {
+		var regExp = new RegExp(word, 'g');
+		var replace = '<span class="highlight">' + word + '</span>';
+		return phrase.replace(regExp, replace);
+	}
 
-    } );
-    function toggle_link_click( element, event ) {
-        if ( clicked_toggle ) {
-            return;
-        }
-        clicked_toggle = true;
-        element.classList.toggle('is-active');
-    }
+	function hide_section() {
+		each.call(sections, hide);
+	}
 
-    // Helper functions
-    function pr_to_header(search) {
-        return search.replace("/", " / ").replace(new RegExp("\\-", "g"), " ").replace(/  +/g, ' ').toLowerCase();
-    }
+	function hide(element) {
+		element.style.display = 'none';
+	}
 
-    function highlight_word(word, phrase) {
-        var regExp = new RegExp(word, 'g');
-        var replace = '<span class="highlight">' + word + '</span>';
-        return phrase.replace(regExp, replace);
-    }
-
-    function hide_section() {
-        each.call( sections, hide );
-    }
-
-    function hide( element ) {
-        element.style.display = 'none';
-    }
-
-    function show( element ) {
-        element.style.display = '';
-    }
+	function show(element) {
+		element.style.display = '';
+	}
 })();

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -82,6 +82,7 @@
 			return index === i ? false : true;
 		});
 		disable_activete_branch_links();
+		trackEvent(element);
 		clicked_activate = true;
 	}
 
@@ -105,6 +106,7 @@
 		}
 		clicked_toggle = true;
 		element.classList.toggle('is-active');
+		trackEvent(element);
 	}
 
 	// Helper functions
@@ -132,5 +134,22 @@
 
 	function show(element) {
 		element.style.display = '';
+	}
+
+	/**
+	 * Track user event such as a click on a button or a link.
+	 *
+	 * @param {string} element Element that was clicked.
+	 */
+	function trackEvent(element) {
+		// Do not track anything if TOS have not been accepted yet and the file isn't enqueued.
+		if (!window.jpTracksAJAX || 'function' !== typeof window.jpTracksAJAX.record_ajax_event) {
+			return;
+		}
+
+		const eventName = element.getAttribute('data-jptracks-name');
+		const eventProp = element.getAttribute('data-jptracks-prop');
+
+		jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
 	}
 })();

--- a/admin/main.php
+++ b/admin/main.php
@@ -43,8 +43,13 @@
 			</span>
 			<span class="dops-foldable-card__secondary" >
 				<span class="dops-foldable-card__summary">
-					<a type="button" href="<?php echo esc_url( JETPACK_BETA_REPORT_URL ); ?>"
-					   class="is-primary jp-form-button dops-button is-primary is-compact" >
+					<a
+						type="button"
+						href="<?php echo esc_url( JETPACK_BETA_REPORT_URL ); ?>"
+						class="is-primary jp-form-button dops-button is-primary is-compact jptracks"
+						data-jptracks-name="jetpack_beta_submit_report"
+						data-jptracks-prop="<?php echo esc_attr( Jetpack_Beta::get_jetpack_plugin_version() ); ?>"
+					>
 						<?php _e( 'Report it!', 'jetpack-beta' ); ?>
 					</a>
 				</span>

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -318,8 +318,13 @@ class Jetpack_Beta_Admin {
 		);
 		$url   = Jetpack_Beta::admin_url( '?' . build_query( $query ) );
 
-		return '<a href="' . esc_url( $url ) . '"
-				class="is-primary jp-form-button activate-branch dops-button is-compact" >' . __( 'Activate', 'jetpack-beta' ) . '</a>';
+		return sprintf(
+			'<a href="%1$s" class="is-primary jp-form-button activate-branch dops-button is-compact jptracks" data-jptracks-name="%2$s" data-jptracks-prop="%3$s">%4$s</a>',
+			esc_url( $url ),
+			'jetpack_beta_activate_branch',
+			esc_attr( $branch ),
+			esc_html__( 'Activate', 'jetpack-beta' )
+		);
 	}
 
 	static function header( $title ) {

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -419,11 +419,15 @@ class Jetpack_Beta_Admin {
 		);
 
 		?>
-		<a href="<?php echo esc_url( Jetpack_Beta::admin_url( '?' . build_query( $query ) ) ); ?>" class="form-toggle__label <?php echo ( $value ? 'is-active' : '' ); ?>"  >
-			<span class="form-toggle-explanation" ><?php esc_html_e( $name ); ?></span>
+		<a
+			href="<?php echo esc_url( Jetpack_Beta::admin_url( '?' . build_query( $query ) ) ); ?>"
+			class="form-toggle__label <?php echo ( $value ? 'is-active' : '' ); ?>"
+			data-jptracks-name="jetpack_beta_toggle_<?php echo esc_attr( $option ); ?>"
+			data-jptracks-prop="<?php echo absint( ! $value ); ?>"
+		>
+			<span class="form-toggle-explanation" ><?php echo esc_html( $name ); ?></span>
 			<span class="form-toggle__switch" tabindex="0" ></span>
-			<span class="form-toggle__label-content" >
-			</span>
+			<span class="form-toggle__label-content" ></span>
 		</a>
 		<?php
 	}


### PR DESCRIPTION
Fixes #74 

This PR adds Tracking to the toggles and branch activation buttons on the Jetpack Beta admin page.
Tracking only happens if one has accepted our ToS, and thus the tracking script is enqueued on that page.

### Testing instructions

1. Enable debug in your browser console: `localStorage.setItem( 'debug', 'dops:analytics' );`
2. Try clicking buttons on a site where Jetpack has never been connected to WordPress.com; you should see nothing.
3. Connect Jetpack to WordPress.com and reload the page.
4. Try clicking the buttons: you should see events being tracked: `jetpack_beta_toggle_autoupdates`, `jetpack_beta_toggle_email_notifications`, `jetpack_beta_activate_branch`, `jetpack_beta_submit_report`, with more details in event props.
5. Check Tracks for your username to see the events coming through.