### PR TITLE
Added a custom error handler that saves to Jetpack log.

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -1176,8 +1176,14 @@ class Jetpack_Beta {
 			Jetpack::log( $errno, $error_string );
 		}
 
-		// If this error is not being reported in the current settings, stop reporting here by returning true.
+		/**
+		 * The error_reporting call returns current error reporting level as an integer. Bitwise
+		 * AND lets us determine whether the current error is included in the current error
+		 * reporting level
+		 */
 		if ( ! ( error_reporting() & $errno ) ) {
+
+			// If this error is not being reported in the current settings, stop reporting here by returning true.
 			return true;
 		}
 

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -1173,7 +1173,11 @@ class Jetpack_Beta {
 
 		if ( class_exists( 'Jetpack' ) && method_exists( 'Jetpack', 'log' ) ) {
 			$error_string = sprintf( "%s, %s:%d", $errstr, $errfile, $errline );
-			Jetpack::log( $errno, $error_string );
+
+			// Only adding to log if the message is related to Jetpack.
+			if ( false !== stripos( $error_string, 'jetpack' ) ) {
+				Jetpack::log( $errno, $error_string );
+			}
 		}
 
 		/**


### PR DESCRIPTION
Fixes #79 

Saves all error output to the option using Jetpack::log.

## Testing instructions

Try to trigger errors when having this plugin installed. You can do something like this:

```
add_action( 'init', function() {
	error_log( 'ADDING AN ERROR' );
	$array = array();
	error_log( $array['undefined offset'] );
})
```
You can see the error log using WP CLI like this:
```
$ wp option get jetpack_log
```

If you add this snippet outside Jetpack code, you won't see it in the error log, this is expected behaviour, because we are filtering the entries by a string match. To actually see the errors in the log, you can add the word `jetpack` into the array key we're trying to get in the code there^ 

```
	error_log( $array['jetpack is bestpack'] );
```

This time you should be able to see the entry in the log.