### PR TITLE
Download tags directly from wp.org SVN

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -25,21 +25,17 @@
             element: element
         }
     });
-    // eslint-disable-next-line
-    console.log( section_index);
 
-    each.call(tag_sections, function (element, index) {
+    each.call( tag_sections, function( element, index ) {
         hide( element );
-        element.querySelector('.activate-branch').setAttribute('data-index', index);
+        element.querySelector( '.activate-branch' ).setAttribute('data-index', index );
         tag_index[index] = {
-            header: element.querySelector('.tag-card-header').textContent,
-            tag: element.getAttribute('data-tag'),
+            header: element.querySelector( '.tag-card-header' ).textContent,
+            tag: element.getAttribute( 'data-tag' ),
             element: element
-        }
-    });
+        };
+    } );
 
-    // eslint-disable-next-line
-    console.log( section_index);
     // Search input
     search_input.addEventListener("keyup", function (event) {
         var search_for = pr_to_header(search_input.value);

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,155 +1,178 @@
-(function() {
-	// Elements
-	var sections = document.getElementById('section-pr').querySelectorAll('.branch-card');
-	var search_input = document.getElementById('search-component');
-	var search_close_link = document.getElementById('search-component-close');
-	var activate_links = document.querySelectorAll('.activate-branch');
-	var toggle_links = document.querySelectorAll('.form-toggle__label');
+(function () {
+    // Elements
+    var sections = document.getElementById('section-pr').querySelectorAll('.branch-card');
+    var tag_sections = document.getElementById('section-tags').querySelectorAll('.tag-card');
+    var search_input = document.getElementById('search-component-prs');
+    var search_tags_input = document.getElementById('search-component-tags');
+    var search_close_link = document.getElementById('search-component-prs-close');
+    var search_close_tags_link = document.getElementById('search-component-tags-close');
+    var activate_links = document.querySelectorAll('.activate-branch');
+    var toggle_links = document.querySelectorAll('.form-toggle__label');
 
-	var section_index = []; //
-	var each = Array.prototype.forEach;
-	var clicked_activate = false;
-	var clicked_toggle = false;
 
-	each.call(sections, function(element, index) {
-		hide(element);
-		element.querySelector('.activate-branch').setAttribute('data-index', index);
-		section_index[index] = {
-			header: element.querySelector('.branch-card-header').textContent,
-			pr: element.getAttribute('data-pr'),
-			element: element,
-		};
-	});
+    var section_index = []; //
+    var tag_index = []; //
+    var each = Array.prototype.forEach;
+    var clicked_activate = false;
+    var clicked_toggle = false;
 
-	// Search input
-	search_input.addEventListener('keyup', function(event) {
-		var search_for = pr_to_header(search_input.value);
+    each.call(sections, function (element, index) {
+        hide( element );
+        element.querySelector('.activate-branch').setAttribute('data-index', index);
+        section_index[index] = {
+            header: element.querySelector('.branch-card-header').textContent,
+            pr: element.getAttribute('data-pr'),
+            element: element
+        }
+    });
+    // eslint-disable-next-line
+    console.log( section_index);
 
-		if (!search_for) {
-			hide(search_close_link);
-			hide_section();
-			return;
-		}
+    each.call(tag_sections, function (element, index) {
+        hide( element );
+        element.querySelector('.activate-branch').setAttribute('data-index', index);
+        tag_index[index] = {
+            header: element.querySelector('.tag-card-header').textContent,
+            tag: element.getAttribute('data-tag'),
+            element: element
+        }
+    });
 
-		show(search_close_link);
-		section_index.forEach(show_found_branches.bind(this, search_for));
-	});
+    // eslint-disable-next-line
+    console.log( section_index);
+    // Search input
+    search_input.addEventListener("keyup", function (event) {
+        var search_for = pr_to_header(search_input.value);
 
-	function show_found_branches(search_for, branch) {
-		var element = branch.element;
-		var header_text = parseInt(search_for) > 0 ? branch.pr.toString() : branch.header;
+        if (!search_for) {
+            hide( search_close_link );
+            hide_section();
+            return;
+        }
 
-		var found_position = header_text.indexOf(search_for);
-		if (-1 === found_position) {
-			hide(element);
-			return;
-		}
+        show( search_close_link );
+        section_index.forEach( show_found_branches.bind( this, search_for ) );
+    });
 
-		element.querySelector('.branch-card-header').innerHTML = highlight_word(
-			search_for,
-			header_text
-		);
-		show(element);
-	}
+    search_tags_input.addEventListener("keyup", function( event ) {
+        var search_for = pr_to_header( search_tags_input.value );
 
-	// Search close link
-	hide(search_close_link);
-	search_close_link.addEventListener('click', function(event) {
-		hide_section();
-		hide(search_close_link);
-		search_input.value = '';
-		event.preventDefault();
-	});
+        if ( ! search_for ) {
+            hide( search_close_tags_link );
+            hide_section();
+            return;
+        }
 
-	// Activate Links
-	each.call(activate_links, function(element, index) {
-		element.addEventListener('click', activate_link_click.bind(this, element));
-	});
+        show( search_close_tags_link );
+        tag_index.forEach( show_found_tags.bind( this, search_for ) );
+    });
 
-	function activate_link_click(element, event) {
-		if (clicked_activate) {
-			return;
-		}
-		if (element.textContent == JetpackBeta.activate) {
-			element.parentNode.textContent = JetpackBeta.activating;
-		} else {
-			element.parentNode.textContent = JetpackBeta.updating;
-		}
+    function show_found_branches(search_for, branch) {
+        var element = branch.element;
+        var header_text = ( parseInt(search_for) > 0 ) ? branch.pr.toString() : branch.header;
 
-		var index = parseInt(element.getAttribute('data-index'));
+        var found_position = header_text.indexOf(search_for);
+        if (-1 === found_position) {
+            hide( element );
+            return;
+        }
 
-		sections = Array.prototype.filter.call(sections, function(element, i) {
-			return index === i ? false : true;
-		});
-		disable_activete_branch_links();
-		trackEvent(element);
-		clicked_activate = true;
-	}
+        element.querySelector('.branch-card-header').innerHTML = highlight_word(search_for, header_text);
+        show( element );
+    }
 
-	function disable_activete_branch_links() {
-		each.call(activate_links, function(element, index) {
-			element.addEventListener('click', function(event) {
-				event.preventDefault();
-			});
-			element.removeEventListener('click', activate_link_click.bind(this, element));
-			element.classList.add('is-disabled');
-		});
-	}
+    function show_found_tags( search_for, tag ) {
+        var element = tag.element;
+        var header_text = ( parseInt( search_for ) > 0 ) ? tag.tag.toString() : tag.header;
 
-	// Toggle Links
-	each.call(toggle_links, function(element, index) {
-		element.addEventListener('click', toggle_link_click.bind(this, element));
-	});
-	function toggle_link_click(element, event) {
-		if (clicked_toggle) {
-			return;
-		}
-		clicked_toggle = true;
-		element.classList.toggle('is-active');
-		trackEvent(element);
-	}
+        var found_position = header_text.indexOf(search_for);
+        if ( -1 === found_position ) {
+            hide( element );
+            return;
+        }
 
-	// Helper functions
-	function pr_to_header(search) {
-		return search
-			.replace('/', ' / ')
-			.replace(new RegExp('\\-', 'g'), ' ')
-			.replace(/  +/g, ' ')
-			.toLowerCase();
-	}
+        element.querySelector( '.tag-card-header' ).innerHTML = highlight_word( search_for, header_text );
+        show( element );
+    }
 
-	function highlight_word(word, phrase) {
-		var regExp = new RegExp(word, 'g');
-		var replace = '<span class="highlight">' + word + '</span>';
-		return phrase.replace(regExp, replace);
-	}
+    // Search close link
+    hide( search_close_link );
+    search_close_link.addEventListener('click', function (event) {
+        hide_section();
+        hide( search_close_link );
+        search_input.value = '';
+        event.preventDefault();
+    });
 
-	function hide_section() {
-		each.call(sections, hide);
-	}
+    // Activate Links
+    each.call(activate_links, function (element, index) {
+        element.addEventListener('click', activate_link_click.bind( this, element ) );
+    });
 
-	function hide(element) {
-		element.style.display = 'none';
-	}
+    function activate_link_click( element, event ) {
+        if ( clicked_activate ) {
+           return;
+        }
+        if ( element.textContent == JetpackBeta.activate ) {
+            element.parentNode.textContent = JetpackBeta.activating;
+        } else {
+            element.parentNode.textContent = JetpackBeta.updating;
+        }
 
-	function show(element) {
-		element.style.display = '';
-	}
+        var index = parseInt( element.getAttribute('data-index') );
 
-	/**
-	 * Track user event such as a click on a button or a link.
-	 *
-	 * @param {string} element Element that was clicked.
-	 */
-	function trackEvent(element) {
-		// Do not track anything if TOS have not been accepted yet and the file isn't enqueued.
-		if (!window.jpTracksAJAX || 'function' !== typeof window.jpTracksAJAX.record_ajax_event) {
-			return;
-		}
+        sections = Array.prototype.filter.call( sections, function( element, i ) {
+            return (index === i ? false: true );
+        } );
+        disable_activete_branch_links();
+        clicked_activate = true;
+    }
 
-		const eventName = element.getAttribute('data-jptracks-name');
-		const eventProp = element.getAttribute('data-jptracks-prop');
+    function disable_activete_branch_links() {
+        each.call(activate_links, function (element, index) {
+            element.addEventListener('click', function (event) {
+                event.preventDefault();
+            } );
+            element.removeEventListener( 'click', activate_link_click.bind( this, element ) );
+            element.classList.add('is-disabled');
+        })
+    }
 
-		jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
-	}
+    // Toggle Links
+    each.call( toggle_links, function( element, index ) {
+        element.addEventListener('click', toggle_link_click.bind( this, element ) );
+
+
+    } );
+    function toggle_link_click( element, event ) {
+        if ( clicked_toggle ) {
+            return;
+        }
+        clicked_toggle = true;
+        element.classList.toggle('is-active');
+    }
+
+    // Helper functions
+    function pr_to_header(search) {
+        return search.replace("/", " / ").replace(new RegExp("\\-", "g"), " ").replace(/  +/g, ' ').toLowerCase();
+    }
+
+    function highlight_word(word, phrase) {
+        var regExp = new RegExp(word, 'g');
+        var replace = '<span class="highlight">' + word + '</span>';
+        return phrase.replace(regExp, replace);
+    }
+
+    function hide_section() {
+        each.call( sections, hide );
+        each.call( tag_sections, hide );
+    }
+
+    function hide( element ) {
+        element.style.display = 'none';
+    }
+
+    function show( element ) {
+        element.style.display = '';
+    }
 })();

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,104 +1,88 @@
 (function () {
     // Elements
-    var sections = document.getElementById('section-pr').querySelectorAll('.branch-card');
-    var tag_sections = document.getElementById('section-tags').querySelectorAll('.tag-card');
-    var search_input = document.getElementById('search-component-prs');
-    var search_tags_input = document.getElementById('search-component-tags');
-    var search_close_link = document.getElementById('search-component-prs-close');
-    var search_close_tags_link = document.getElementById('search-component-tags-close');
+    var prs = document.getElementById('section-pr').querySelectorAll('.branch-card');
+    var tags = document.getElementById( 'section-tags' ).querySelectorAll( '.tag-card' );
+    var search_input_prs = document.getElementById('search-component-prs');
+    var search_input_tags = document.getElementById('search-component-tags');
+    var search_close_link_prs = document.getElementById('search-component-prs-close');
+    var search_close_link_tags = document.getElementById('search-component-tags-close');
     var activate_links = document.querySelectorAll('.activate-branch');
     var toggle_links = document.querySelectorAll('.form-toggle__label');
 
 
-    var section_index = []; //
-    var tag_index = []; //
+    var pr_index = [];
+    var tag_index = [];
     var each = Array.prototype.forEach;
     var clicked_activate = false;
     var clicked_toggle = false;
 
-    each.call(sections, function (element, index) {
+    // Build index of prs
+    each.call( prs, function( element, index ) {
         hide( element );
-        element.querySelector('.activate-branch').setAttribute('data-index', index);
-        section_index[index] = {
-            header: element.querySelector('.branch-card-header').textContent,
-            pr: element.getAttribute('data-pr'),
+        element.querySelector( '.activate-branch' ).setAttribute( 'data-index', index );
+        pr_index[index] = {
+            header: element.querySelector( '.branch-card-header' ).textContent,
+            key: element.getAttribute( 'data-pr' ),
             element: element
         }
-    });
+    } );
 
-    each.call( tag_sections, function( element, index ) {
+    // Build index of tags
+    each.call( tags, function( element, index ) {
         hide( element );
         element.querySelector( '.activate-branch' ).setAttribute('data-index', index );
         tag_index[index] = {
             header: element.querySelector( '.tag-card-header' ).textContent,
-            tag: element.getAttribute( 'data-tag' ),
+            key: element.getAttribute( 'data-tag' ),
             element: element
         };
     } );
 
-    // Search input
-    search_input.addEventListener("keyup", function (event) {
-        var search_for = pr_to_header(search_input.value);
+    search_input_listener( search_input_prs );
+    search_input_listener( search_input_tags );
+    function search_input_listener( input_area ) {
+        input_area.addEventListener( 'keyup', function( event ) {
+            var section_id = event.srcElement.id;
+            var search_for = pr_to_header( input_area.value );
+            var index = 'search-component-tags' === section_id ? tag_index : pr_index;
 
-        if (!search_for) {
-            hide( search_close_link );
-            hide_section();
-            return;
-        }
+            if ( ! search_for ) {
+                hide_section();
+                return;
+            }
 
-        show( search_close_link );
-        section_index.forEach( show_found_branches.bind( this, search_for ) );
-    });
-
-    search_tags_input.addEventListener("keyup", function( event ) {
-        var search_for = pr_to_header( search_tags_input.value );
-
-        if ( ! search_for ) {
-            hide( search_close_tags_link );
-            hide_section();
-            return;
-        }
-
-        show( search_close_tags_link );
-        tag_index.forEach( show_found_tags.bind( this, search_for ) );
-    });
-
-    function show_found_branches(search_for, branch) {
-        var element = branch.element;
-        var header_text = ( parseInt(search_for) > 0 ) ? branch.pr.toString() : branch.header;
-
-        var found_position = header_text.indexOf(search_for);
-        if (-1 === found_position) {
-            hide( element );
-            return;
-        }
-
-        element.querySelector('.branch-card-header').innerHTML = highlight_word(search_for, header_text);
-        show( element );
+            show( search_close_link_tags );
+            index.forEach( show_found.bind( this, search_for, section_id ) );
+        } );
     }
 
-    function show_found_tags( search_for, tag ) {
-        var element = tag.element;
-        var header_text = ( parseInt( search_for ) > 0 ) ? tag.tag.toString() : tag.header;
+    function show_found( search_for, section, found ) {
+        var element = found.element;
+        var header_text = ( parseInt(search_for) > 0 ) ? found.key.toString() : found.header;
+        var class_selector = 'search-component-tags' === section ? '.tag-card-header' : '.branch-card-header';
 
-        var found_position = header_text.indexOf(search_for);
+        var found_position = header_text.indexOf( search_for );
         if ( -1 === found_position ) {
             hide( element );
             return;
         }
 
-        element.querySelector( '.tag-card-header' ).innerHTML = highlight_word( search_for, header_text );
+        element.querySelector( class_selector ).innerHTML = highlight_word( search_for, header_text );
         show( element );
     }
 
-    // Search close link
-    hide( search_close_link );
-    search_close_link.addEventListener('click', function (event) {
-        hide_section();
-        hide( search_close_link );
-        search_input.value = '';
-        event.preventDefault();
-    });
+    // Hiding the search close link
+    hide_search_close_link( search_close_link_prs );
+    hide_search_close_link( search_close_link_tags );
+    function hide_search_close_link( section ) {
+        hide( section );
+        section.addEventListener( 'click', function( event ) {
+            hide_section();
+            hide( section );
+            search_input.value = '';
+            event.preventDefault();
+        } );
+    }
 
     // Activate Links
     each.call(activate_links, function (element, index) {
@@ -117,7 +101,7 @@
 
         var index = parseInt( element.getAttribute('data-index') );
 
-        sections = Array.prototype.filter.call( sections, function( element, i ) {
+        prs = Array.prototype.filter.call( prs, function( element, i ) {
             return (index === i ? false: true );
         } );
         disable_activete_branch_links();
@@ -160,8 +144,8 @@
     }
 
     function hide_section() {
-        each.call( sections, hide );
-        each.call( tag_sections, hide );
+        each.call( prs, hide );
+        each.call( tags, hide );
     }
 
     function hide( element ) {

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,158 +1,179 @@
-(function () {
-    // Elements
-    var prs = document.getElementById('section-pr').querySelectorAll('.branch-card');
-    var tags = document.getElementById( 'section-tags' ).querySelectorAll( '.tag-card' );
-    var search_input_prs = document.getElementById('search-component-prs');
-    var search_input_tags = document.getElementById('search-component-tags');
-    var search_close_link_prs = document.getElementById('search-component-prs-close');
-    var search_close_link_tags = document.getElementById('search-component-tags-close');
-    var activate_links = document.querySelectorAll('.activate-branch');
-    var toggle_links = document.querySelectorAll('.form-toggle__label');
+(function() {
+	// Elements
+	var prs = document.getElementById('section-pr').querySelectorAll('.branch-card');
+	var tags = document.getElementById('section-tags').querySelectorAll('.tag-card');
+	var search_input_prs = document.getElementById('search-component-prs');
+	var search_input_tags = document.getElementById('search-component-tags');
+	var search_close_link_prs = document.getElementById('search-component-prs-close');
+	var search_close_link_tags = document.getElementById('search-component-tags-close');
+	var activate_links = document.querySelectorAll('.activate-branch');
+	var toggle_links = document.querySelectorAll('.form-toggle__label');
 
+	var pr_index = [];
+	var tag_index = [];
+	var each = Array.prototype.forEach;
+	var clicked_activate = false;
+	var clicked_toggle = false;
 
-    var pr_index = [];
-    var tag_index = [];
-    var each = Array.prototype.forEach;
-    var clicked_activate = false;
-    var clicked_toggle = false;
+	// Build index of prs
+	each.call(prs, function(element, index) {
+		hide(element);
+		element.querySelector('.activate-branch').setAttribute('data-index', index);
+		pr_index[index] = {
+			header: element.querySelector('.branch-card-header').textContent,
+			key: element.getAttribute('data-pr'),
+			element: element,
+		};
+	});
 
-    // Build index of prs
-    each.call( prs, function( element, index ) {
-        hide( element );
-        element.querySelector( '.activate-branch' ).setAttribute( 'data-index', index );
-        pr_index[index] = {
-            header: element.querySelector( '.branch-card-header' ).textContent,
-            key: element.getAttribute( 'data-pr' ),
-            element: element
-        }
-    } );
+	// Build index of tags
+	each.call(tags, function(element, index) {
+		hide(element);
+		element.querySelector('.activate-branch').setAttribute('data-index', index);
+		tag_index[index] = {
+			header: element.querySelector('.tag-card-header').textContent,
+			key: element.getAttribute('data-tag'),
+			element: element,
+		};
+	});
 
-    // Build index of tags
-    each.call( tags, function( element, index ) {
-        hide( element );
-        element.querySelector( '.activate-branch' ).setAttribute('data-index', index );
-        tag_index[index] = {
-            header: element.querySelector( '.tag-card-header' ).textContent,
-            key: element.getAttribute( 'data-tag' ),
-            element: element
-        };
-    } );
+	search_input_listener(search_input_prs);
+	search_input_listener(search_input_tags);
+	function search_input_listener(input_area) {
+		input_area.addEventListener('keyup', function(event) {
+			var section_id = event.srcElement.id;
+			var search_for = pr_to_header(input_area.value);
+			var index = 'search-component-tags' === section_id ? tag_index : pr_index;
 
-    search_input_listener( search_input_prs );
-    search_input_listener( search_input_tags );
-    function search_input_listener( input_area ) {
-        input_area.addEventListener( 'keyup', function( event ) {
-            var section_id = event.srcElement.id;
-            var search_for = pr_to_header( input_area.value );
-            var index = 'search-component-tags' === section_id ? tag_index : pr_index;
+			if (!search_for) {
+				hide_section();
+				return;
+			}
 
-            if ( ! search_for ) {
-                hide_section();
-                return;
-            }
+			show(search_close_link_tags);
+			index.forEach(show_found.bind(this, search_for, section_id));
+		});
+	}
 
-            show( search_close_link_tags );
-            index.forEach( show_found.bind( this, search_for, section_id ) );
-        } );
-    }
+	function show_found(search_for, section, found) {
+		var element = found.element;
+		var header_text = parseInt(search_for) > 0 ? found.key.toString() : found.header;
+		var class_selector =
+			'search-component-tags' === section ? '.tag-card-header' : '.branch-card-header';
 
-    function show_found( search_for, section, found ) {
-        var element = found.element;
-        var header_text = ( parseInt(search_for) > 0 ) ? found.key.toString() : found.header;
-        var class_selector = 'search-component-tags' === section ? '.tag-card-header' : '.branch-card-header';
+		var found_position = header_text.indexOf(search_for);
+		if (-1 === found_position) {
+			hide(element);
+			return;
+		}
 
-        var found_position = header_text.indexOf( search_for );
-        if ( -1 === found_position ) {
-            hide( element );
-            return;
-        }
+		element.querySelector(class_selector).innerHTML = highlight_word(search_for, header_text);
+		show(element);
+	}
 
-        element.querySelector( class_selector ).innerHTML = highlight_word( search_for, header_text );
-        show( element );
-    }
+	// Hiding the search close link
+	hide_search_close_link(search_close_link_prs);
+	hide_search_close_link(search_close_link_tags);
+	function hide_search_close_link(section) {
+		hide(section);
+		section.addEventListener('click', function(event) {
+			hide_section();
+			hide(section);
+			search_input.value = '';
+			event.preventDefault();
+		});
+	}
 
-    // Hiding the search close link
-    hide_search_close_link( search_close_link_prs );
-    hide_search_close_link( search_close_link_tags );
-    function hide_search_close_link( section ) {
-        hide( section );
-        section.addEventListener( 'click', function( event ) {
-            hide_section();
-            hide( section );
-            search_input.value = '';
-            event.preventDefault();
-        } );
-    }
+	// Activate Links
+	each.call(activate_links, function(element, index) {
+		element.addEventListener('click', activate_link_click.bind(this, element));
+	});
 
-    // Activate Links
-    each.call(activate_links, function (element, index) {
-        element.addEventListener('click', activate_link_click.bind( this, element ) );
-    });
+	function activate_link_click(element, event) {
+		if (clicked_activate) {
+			return;
+		}
+		if (element.textContent == JetpackBeta.activate) {
+			element.parentNode.textContent = JetpackBeta.activating;
+		} else {
+			element.parentNode.textContent = JetpackBeta.updating;
+		}
 
-    function activate_link_click( element, event ) {
-        if ( clicked_activate ) {
-           return;
-        }
-        if ( element.textContent == JetpackBeta.activate ) {
-            element.parentNode.textContent = JetpackBeta.activating;
-        } else {
-            element.parentNode.textContent = JetpackBeta.updating;
-        }
+		var index = parseInt(element.getAttribute('data-index'));
 
-        var index = parseInt( element.getAttribute('data-index') );
+		prs = Array.prototype.filter.call(prs, function(element, i) {
+			return index === i ? false : true;
+		});
+		disable_activete_branch_links();
+		trackEvent(element);
+		clicked_activate = true;
+	}
 
-        prs = Array.prototype.filter.call( prs, function( element, i ) {
-            return (index === i ? false: true );
-        } );
-        disable_activete_branch_links();
-        clicked_activate = true;
-    }
+	function disable_activete_branch_links() {
+		each.call(activate_links, function(element, index) {
+			element.addEventListener('click', function(event) {
+				event.preventDefault();
+			});
+			element.removeEventListener('click', activate_link_click.bind(this, element));
+			element.classList.add('is-disabled');
+		});
+	}
 
-    function disable_activete_branch_links() {
-        each.call(activate_links, function (element, index) {
-            element.addEventListener('click', function (event) {
-                event.preventDefault();
-            } );
-            element.removeEventListener( 'click', activate_link_click.bind( this, element ) );
-            element.classList.add('is-disabled');
-        })
-    }
+	// Toggle Links
+	each.call(toggle_links, function(element, index) {
+		element.addEventListener('click', toggle_link_click.bind(this, element));
+	});
+	function toggle_link_click(element, event) {
+		if (clicked_toggle) {
+			return;
+		}
+		clicked_toggle = true;
+		element.classList.toggle('is-active');
+		trackEvent(element);
+	}
 
-    // Toggle Links
-    each.call( toggle_links, function( element, index ) {
-        element.addEventListener('click', toggle_link_click.bind( this, element ) );
+	// Helper functions
+	function pr_to_header(search) {
+		return search
+			.replace('/', ' / ')
+			.replace(new RegExp('\\-', 'g'), ' ')
+			.replace(/  +/g, ' ')
+			.toLowerCase();
+	}
 
+	function highlight_word(word, phrase) {
+		var regExp = new RegExp(word, 'g');
+		var replace = '<span class="highlight">' + word + '</span>';
+		return phrase.replace(regExp, replace);
+	}
 
-    } );
-    function toggle_link_click( element, event ) {
-        if ( clicked_toggle ) {
-            return;
-        }
-        clicked_toggle = true;
-        element.classList.toggle('is-active');
-    }
+	function hide_section() {
+		each.call(prs, hide);
+		each.call(tags, hide);
+	}
 
-    // Helper functions
-    function pr_to_header(search) {
-        return search.replace("/", " / ").replace(new RegExp("\\-", "g"), " ").replace(/  +/g, ' ').toLowerCase();
-    }
+	function hide(element) {
+		element.style.display = 'none';
+	}
 
-    function highlight_word(word, phrase) {
-        var regExp = new RegExp(word, 'g');
-        var replace = '<span class="highlight">' + word + '</span>';
-        return phrase.replace(regExp, replace);
-    }
+	function show(element) {
+		element.style.display = '';
+	}
 
-    function hide_section() {
-        each.call( prs, hide );
-        each.call( tags, hide );
-    }
+	/**
+	 * Track user event such as a click on a button or a link.
+	 *
+	 * @param {string} element Element that was clicked.
+	 */
+	function trackEvent(element) {
+		// Do not track anything if TOS have not been accepted yet and the file isn't enqueued.
+		if (!window.jpTracksAJAX || 'function' !== typeof window.jpTracksAJAX.record_ajax_event) {
+			return;
+		}
 
-    function hide( element ) {
-        element.style.display = 'none';
-    }
+		const eventName = element.getAttribute('data-jptracks-name');
+		const eventProp = element.getAttribute('data-jptracks-prop');
 
-    function show( element ) {
-        element.style.display = '';
-    }
+		jpTracksAJAX.record_ajax_event(eventName, 'click', eventProp);
+	}
 })();

--- a/admin/main.php
+++ b/admin/main.php
@@ -68,6 +68,8 @@
 		Jetpack_Beta_Admin::show_branch( __( 'Bleeding Edge' ), 'master', null, 'master' );
 		Jetpack_Beta_Admin::show_search_prs();
 		Jetpack_Beta_Admin::show_branches( 'pr' );
+		Jetpack_Beta_Admin::show_search_org_tags();
+		Jetpack_Beta_Admin::show_tags( 'org' );
 	?>
 	</div>
 

--- a/admin/main.php
+++ b/admin/main.php
@@ -69,7 +69,7 @@
 		Jetpack_Beta_Admin::show_search_prs();
 		Jetpack_Beta_Admin::show_branches( 'pr' );
 		Jetpack_Beta_Admin::show_search_org_tags();
-		Jetpack_Beta_Admin::show_tags( 'org' );
+		Jetpack_Beta_Admin::show_tags( 'tags' );
 	?>
 	</div>
 

--- a/admin/main.php
+++ b/admin/main.php
@@ -26,7 +26,9 @@
 				</span>
 				<span class="dops-foldable-card__secondary">
 					<?php Jetpack_Beta_Admin::show_toggle_emails(); ?>
+					<?php if ( ! Jetpack_Beta::is_on_tag() ) : ?>
 					<?php Jetpack_Beta_Admin::show_toggle_autoupdates(); ?>
+					<?php endif; ?>
 				</span>
 			</div>
 			<div class="dops-foldable-card__content">

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -324,10 +324,13 @@ class Jetpack_Beta_Admin {
 		<div class="dops-foldable-card__header has-border" >
 				<span class="dops-foldable-card__main">
 					<div class="dops-foldable-card__header-text">
-						<div class="dops-foldable-card__header-text tag-card-header"><?php echo esc_html( $header ); ?></div>
+						<div class="dops-foldable-card__header-text tag-card-header">Jetpack <?php echo esc_html( $header ); ?></div>
 						<div class="dops-foldable-card__subheader">
 						<?php
-						echo $tag;
+						printf(
+							'Official tag <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%s" target="_blank">%s</a> downloaded from wp.org',
+							esc_attr( $tag ), esc_html( $tag )
+						);
 						?>
 						</div>
 					</div>

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -324,7 +324,7 @@ class Jetpack_Beta_Admin {
 		<div class="dops-foldable-card__header has-border" >
 				<span class="dops-foldable-card__main">
 					<div class="dops-foldable-card__header-text">
-						<div class="dops-foldable-card__header-text branch-card-header"><?php echo esc_html( $header ); ?></div>
+						<div class="dops-foldable-card__header-text tag-card-header"><?php echo esc_html( $header ); ?></div>
 						<div class="dops-foldable-card__subheader">
 						<?php
 						echo $tag;
@@ -404,7 +404,7 @@ class Jetpack_Beta_Admin {
 		if ( empty( $manifest->versions ) ) {
 			return;
 		}
-		$tags = (array) $manifest->versions;
+		$tags = array_reverse( (array) $manifest->versions );
 		$count_all = count( $tags );
 
 		foreach ( $tags as $tag => $url ) {
@@ -447,9 +447,9 @@ class Jetpack_Beta_Admin {
 								</g>
 							</svg>
 						</div>
-						<input aria-hidden="false" class="dops-search__input" id="search-component"
+						<input aria-hidden="false" class="dops-search__input" id="search-component-prs"
 						       placeholder="<?php esc_attr_e( 'Search for a Jetpack Feature Branch', 'jetpack-beta' ); ?>" role="search" type="search" value="">
-						<span aria-controls="search-component" id="search-component-close" aria-label="<?php esc_attr_e( 'Close Search','jetpack-beta'); ?>"
+						<span aria-controls="search-component" id="search-component-prs-close" aria-label="<?php esc_attr_e( 'Close Search','jetpack-beta'); ?>"
 						      tabindex="0">
 							<svg class="gridicon gridicons-cross dops-search-close__icon" height="24"
 							     viewbox="0 0 24 24" width="24">
@@ -483,9 +483,9 @@ class Jetpack_Beta_Admin {
 								</g>
 							</svg>
 						</div>
-						<input aria-hidden="false" class="dops-search__input" id="search-component"
+						<input aria-hidden="false" class="dops-search__input" id="search-component-tags"
 						       placeholder="<?php esc_attr_e( 'Search for a Jetpack tag', 'jetpack-beta' ); ?>" role="search" type="search" value="">
-						<span aria-controls="search-component" id="search-component-close" aria-label="<?php esc_attr_e( 'Close Search','jetpack-beta'); ?>"
+						<span aria-controls="search-component" id="search-component-tags-close" aria-label="<?php esc_attr_e( 'Close Search','jetpack-beta'); ?>"
 						      tabindex="0">
 							<svg class="gridicon gridicons-cross dops-search-close__icon" height="24"
 							     viewbox="0 0 24 24" width="24">

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -305,14 +305,14 @@ class Jetpack_Beta_Admin {
 	static function show_tag( $header, $tag, $url = null, $section = null, $is_last = false ) {
 		$is_compact = $is_last ? '' : 'is-compact';
 		if ( isset( $url ) ) {
-			$pr = sprintf( 'data-tag="%s"', esc_attr( $tag ) );
+			$tag = sprintf( 'data-tag="%s"', esc_attr( $tag ) );
 		}
 
-		$branch_class = 'tag-card';
+		$className = 'tag-card';
 		list( $current_branch, $current_section ) = Jetpack_Beta::get_branch_and_section();
 		if ( $current_branch === $tag && $current_section === $section ) {
-			$action       = __( 'Active', 'jetpack-beta' );
-			$branch_class = 'tag-card-active';
+			$action    = __( 'Active', 'jetpack-beta' );
+			$className = 'tag-card-active';
 		} else {
 			$action = self::activate_button( $tag, $section );
 		}
@@ -320,27 +320,27 @@ class Jetpack_Beta_Admin {
 		$header = str_replace( '-', ' ', $header );
 		$header = str_replace( '_', ' / ', $header );
 		?>
-		<div <?php echo $pr; ?> " class="dops-foldable-card <?php echo esc_attr( $branch_class ); ?> has-expanded-summary dops-card <?php echo $is_compact; ?>">
-		<div class="dops-foldable-card__header has-border" >
+		<div <?php echo $tag; ?> " class="dops-foldable-card <?php echo esc_attr( $className ); ?> has-expanded-summary dops-card <?php echo $is_compact; ?>">
+			<div class="dops-foldable-card__header has-border">
 				<span class="dops-foldable-card__main">
 					<div class="dops-foldable-card__header-text">
 						<div class="dops-foldable-card__header-text tag-card-header">Jetpack <?php echo esc_html( $header ); ?></div>
 						<div class="dops-foldable-card__subheader">
 						<?php
-						printf(
-							'Official tag <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%s" target="_blank">%s</a> downloaded from wp.org',
+						sprintf(
+							__( 'Official tag <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%s" target="_blank">%s</a> downloaded from wp.org', 'jetpack-beta' ),
 							esc_attr( $tag ), esc_html( $tag )
 						);
 						?>
 						</div>
 					</div>
 				</span>
-			<span class="dops-foldable-card__secondary">
+				<span class="dops-foldable-card__secondary">
 					<span class="dops-foldable-card__summary">
 						<?php echo $action; ?>
 					</span>
 				</span>
-		</div>
+			</div>
 		</div>
 		<?php
 	}

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -328,8 +328,9 @@ class Jetpack_Beta_Admin {
 						<div class="dops-foldable-card__subheader">
 						<?php
 						sprintf(
-							__( 'Official tag <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%s" target="_blank">%s</a> downloaded from wp.org', 'jetpack-beta' ),
-							esc_attr( $tag ), esc_html( $tag )
+							__( 'Public release (%1$s) <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%2$s" target="_blank" rel="">available on WordPress.org</a>', 'jetpack-beta' ),
+							esc_html( $tag ),
+							esc_attr( $tag )
 						);
 						?>
 						</div>

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -302,6 +302,46 @@ class Jetpack_Beta_Admin {
 		<?php
 	}
 
+	static function show_tag( $header, $tag, $url = null, $section = null, $is_last = false ) {
+		$is_compact = $is_last ? '' : 'is-compact';
+		if ( isset( $url ) ) {
+			$pr = sprintf( 'data-tag="%s"', esc_attr( $tag ) );
+		}
+
+		$branch_class = 'tag-card';
+		list( $current_branch, $current_section ) = Jetpack_Beta::get_branch_and_section();
+		if ( $current_branch === $tag && $current_section === $section ) {
+			$action       = __( 'Active', 'jetpack-beta' );
+			$branch_class = 'tag-card-active';
+		} else {
+			$action = self::activate_button( $tag, $section );
+		}
+
+		$header = str_replace( '-', ' ', $header );
+		$header = str_replace( '_', ' / ', $header );
+		?>
+		<div <?php echo $pr; ?> " class="dops-foldable-card <?php echo esc_attr( $branch_class ); ?> has-expanded-summary dops-card <?php echo $is_compact; ?>">
+		<div class="dops-foldable-card__header has-border" >
+				<span class="dops-foldable-card__main">
+					<div class="dops-foldable-card__header-text">
+						<div class="dops-foldable-card__header-text branch-card-header"><?php echo esc_html( $header ); ?></div>
+						<div class="dops-foldable-card__subheader">
+						<?php
+						echo $tag;
+						?>
+						</div>
+					</div>
+				</span>
+			<span class="dops-foldable-card__secondary">
+					<span class="dops-foldable-card__summary">
+						<?php echo $action; ?>
+					</span>
+				</span>
+		</div>
+		</div>
+		<?php
+	}
+
 	static function activate_button( $branch, $section ) {
 		if ( is_object( $section ) && $branch === 'master' ) {
 			$section = 'master';
@@ -353,6 +393,28 @@ class Jetpack_Beta_Admin {
 		echo '</div>';
 	}
 
+	static function show_tags( $section, $title = null ) {
+		if ( $title ) {
+			$title .= ': ';
+		}
+		echo '<div id="section-' . esc_attr( $section ) . '">';
+
+		$manifest = Jetpack_Beta::get_org_data();
+		$count    = 0;
+		if ( empty( $manifest->versions ) ) {
+			return;
+		}
+		$tags = (array) $manifest->versions;
+		$count_all = count( $tags );
+
+		foreach ( $tags as $tag => $url ) {
+			$count ++;
+			$is_last = $count_all === $count ? true : false;
+			self::show_tag( $title . $tag, $tag, $url, $section, $is_last );
+		}
+		echo '</div>';
+	}
+
 	static function show_stable_branch() {
 		$org_data = Jetpack_Beta::get_org_data();
 
@@ -387,6 +449,42 @@ class Jetpack_Beta_Admin {
 						</div>
 						<input aria-hidden="false" class="dops-search__input" id="search-component"
 						       placeholder="<?php esc_attr_e( 'Search for a Jetpack Feature Branch', 'jetpack-beta' ); ?>" role="search" type="search" value="">
+						<span aria-controls="search-component" id="search-component-close" aria-label="<?php esc_attr_e( 'Close Search','jetpack-beta'); ?>"
+						      tabindex="0">
+							<svg class="gridicon gridicons-cross dops-search-close__icon" height="24"
+							     viewbox="0 0 24 24" width="24">
+								<g>
+									<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z"></path>
+								</g>
+							</svg>
+						</span>
+					</div>
+				</div>
+			</div>
+		</div>
+		<?php
+	}
+
+	static function show_search_org_tags() {
+		$org_data = Jetpack_Beta::get_org_data();
+		if ( empty( $org_data->versions ) ) {
+			return;
+		}
+		?>
+		<div class="dops-navigation">
+			<div class="dops-section-nav has-pinned-items">
+				<div class="dops-section-nav__panel">
+					<div class="is-pinned is-open dops-search" role="search">
+						<div aria-controls="search-component" aria-label="<?php esc_attr_e( 'Open Search', 'jetpack-beta' ); ?>" tabindex="-1">
+							<svg class="gridicon gridicons-search dops-search-open__icon" height="24"
+							     viewbox="0 0 24 24" width="24">
+								<g>
+									<path d="M21 19l-5.154-5.154C16.574 12.742 17 11.42 17 10c0-3.866-3.134-7-7-7s-7 3.134-7 7 3.134 7 7 7c1.42 0 2.742-.426 3.846-1.154L19 21l2-2zM5 10c0-2.757 2.243-5 5-5s5 2.243 5 5-2.243 5-5 5-5-2.243-5-5z"></path>
+								</g>
+							</svg>
+						</div>
+						<input aria-hidden="false" class="dops-search__input" id="search-component"
+						       placeholder="<?php esc_attr_e( 'Search for a Jetpack tag', 'jetpack-beta' ); ?>" role="search" type="search" value="">
 						<span aria-controls="search-component" id="search-component-close" aria-label="<?php esc_attr_e( 'Close Search','jetpack-beta'); ?>"
 						      tabindex="0">
 							<svg class="gridicon gridicons-cross dops-search-close__icon" height="24"

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -305,7 +305,7 @@ class Jetpack_Beta_Admin {
 	static function show_tag( $header, $tag, $url = null, $section = null, $is_last = false ) {
 		$is_compact = $is_last ? '' : 'is-compact';
 		if ( isset( $url ) ) {
-			$tag = sprintf( 'data-tag="%s"', esc_attr( $tag ) );
+			$data_tag = sprintf( 'data-tag="%s"', $tag );
 		}
 
 		$className = 'tag-card';
@@ -320,7 +320,7 @@ class Jetpack_Beta_Admin {
 		$header = str_replace( '-', ' ', $header );
 		$header = str_replace( '_', ' / ', $header );
 		?>
-		<div <?php echo $tag; ?> " class="dops-foldable-card <?php echo esc_attr( $className ); ?> has-expanded-summary dops-card <?php echo $is_compact; ?>">
+		<div <?php echo $data_tag; ?> " class="dops-foldable-card <?php echo esc_attr( $className ); ?> has-expanded-summary dops-card <?php echo $is_compact; ?>">
 			<div class="dops-foldable-card__header has-border">
 				<span class="dops-foldable-card__main">
 					<div class="dops-foldable-card__header-text">

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -246,7 +246,7 @@ class Jetpack_Beta {
 
 	public static function get_plugin_slug() {
 		$installed = self::get_branch_and_section();
-		if ( empty( $installed ) || $installed[1] === 'stable' ) {
+		if ( empty( $installed ) || $installed[1] === 'stable' || $installed[1] === 'tags' ) {
 			return 'jetpack';
 		}
 		return JETPACK_DEV_PLUGIN_SLUG;
@@ -478,6 +478,14 @@ class Jetpack_Beta {
 		return false;
 	}
 
+	static function is_on_tag() {
+		$option = (array) self::get_option();
+		if ( $option[1] == 'tags' ) {
+			return true;
+		}
+		return false;
+	}
+
 	static function get_branch_and_section_dev() {
 		$option = (array) self::get_dev_installed();
 		if ( false !== $option[0] && isset( $option[1] )) {
@@ -506,6 +514,13 @@ class Jetpack_Beta {
 
 		if ( 'stable' === $section ) {
 			return 'Latest Stable';
+		}
+
+		if ( 'tags' === $section ) {
+			return sprintf(
+				'Official <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%s" target="_blank">tag</a> downloaded from wp.org svn',
+				esc_attr( $branch )
+			);
 		}
 
 		if ( 'rc' === $section ) {
@@ -632,6 +647,7 @@ class Jetpack_Beta {
 			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		}
 		$plugin_file_path = WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $plugin_file;
+
 		if ( file_exists( $plugin_file_path ) ) {
 			return get_plugin_data( WP_PLUGIN_DIR . DIRECTORY_SEPARATOR . $plugin_file );
 		}

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -585,9 +585,9 @@ class Jetpack_Beta {
 		if ( 'stable' === $section ) {
 			$org_data = self::get_org_data();
 			return $org_data->download_link;
-		} else if ( 'tag' === $section ) {
+		} else if ( 'tags' === $section ) {
 			$org_data = self::get_org_data();
-			return $org_data->versios->{$branch} ?: false;
+			return $org_data->versions->{$branch} ?: false;
 		}
 		$manifest = Jetpack_Beta::get_beta_manifest( true );
 
@@ -779,7 +779,7 @@ class Jetpack_Beta {
 	static function proceed_to_install_and_activate( $url, $plugin_folder = JETPACK_DEV_PLUGIN_SLUG, $section ) {
 		self::proceed_to_install( $url, $plugin_folder, $section );
 
-		if ( 'stable' === $section || 'tag' === $section ) {
+		if ( 'stable' === $section || 'tags' === $section ) {
 			self::replace_active_plugin( JETPACK_DEV_PLUGIN_FILE, JETPACK_PLUGIN_FILE, true );
 		} else {
 			self::replace_active_plugin( JETPACK_PLUGIN_FILE, JETPACK_DEV_PLUGIN_FILE, true );

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -518,7 +518,7 @@ class Jetpack_Beta {
 
 		if ( 'tags' === $section ) {
 			return sprintf(
-				'Official <a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%s" target="_blank">tag</a> downloaded from wp.org svn',
+				__( 'Public release (<a href="https://plugins.trac.wordpress.org/browser/jetpack/tags/%1$s" target="_blank" rel="noopener noreferrer">available on WordPress.org</a>)', 'jetpack-beta' ),
 				esc_attr( $branch )
 			);
 		}

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -817,7 +817,7 @@ class Jetpack_Beta {
 		}
 
 		global $wp_filesystem;
-		if ( 'stable' === $section || 'tag' === $section ) {
+		if ( 'stable' === $section || 'tags' === $section ) {
 			$plugin_path = WP_PLUGIN_DIR;
 		} else {
 			$plugin_path = str_replace( ABSPATH, $wp_filesystem->abspath(), WP_PLUGIN_DIR  );
@@ -885,6 +885,11 @@ class Jetpack_Beta {
 			return false;
 		}
 
+		// Check if running a tag directly from svn
+		if ( Jetpack_Beta::is_on_tag() ) {
+			return false;
+		}
+
 		$updates = get_site_transient( 'update_plugins' );
 
 		if ( isset( $updates->response, $updates->response[ JETPACK_PLUGIN_FILE ] ) ) {
@@ -905,7 +910,7 @@ class Jetpack_Beta {
 	static function should_update_dev_to_master() {
 		list( $branch, $section ) = self::get_branch_and_section_dev();
 
-		if ( false === $branch || 'master' === $section || 'rc' === $section ) {
+		if ( false === $branch || 'master' === $section || 'rc' === $section || 'tags' === $section ) {
 			return false;
 		}
 		$manifest = self::get_beta_manifest();

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -585,6 +585,9 @@ class Jetpack_Beta {
 		if ( 'stable' === $section ) {
 			$org_data = self::get_org_data();
 			return $org_data->download_link;
+		} else if ( 'tag' === $section ) {
+			$org_data = self::get_org_data();
+			return $org_data->versios->{$branch} ?: false;
 		}
 		$manifest = Jetpack_Beta::get_beta_manifest( true );
 
@@ -776,7 +779,7 @@ class Jetpack_Beta {
 	static function proceed_to_install_and_activate( $url, $plugin_folder = JETPACK_DEV_PLUGIN_SLUG, $section ) {
 		self::proceed_to_install( $url, $plugin_folder, $section );
 
-		if ( 'stable' === $section ) {
+		if ( 'stable' === $section || 'tag' === $section ) {
 			self::replace_active_plugin( JETPACK_DEV_PLUGIN_FILE, JETPACK_PLUGIN_FILE, true );
 		} else {
 			self::replace_active_plugin( JETPACK_PLUGIN_FILE, JETPACK_DEV_PLUGIN_FILE, true );
@@ -798,7 +801,7 @@ class Jetpack_Beta {
 		}
 
 		global $wp_filesystem;
-		if ( 'stable' === $section ) {
+		if ( 'stable' === $section || 'tag' === $section ) {
 			$plugin_path = WP_PLUGIN_DIR;
 		} else {
 			$plugin_path = str_replace( ABSPATH, $wp_filesystem->abspath(), WP_PLUGIN_DIR  );


### PR DESCRIPTION
Fixes #83 
Fixes #66 

Adds a new search field for wp.org tags/trunk. 

![image](https://user-images.githubusercontent.com/7129409/61877777-b75eb500-aebd-11e9-945b-6c6479e57662.png)

It's not very DRY.  I ran into the classic "Should I refactor everything or copy/paste", and decided on the latter. I actually somewhat like the clear distinction between the two searches, even at the expense of some duplicate code. At the same time, maybe I'm just telling myself that because it's easier right now. Any way, I don't see us needing to expand this very often anyway. 

Test: 
- No console errors 
- Activating a stable tag or trunk should reflect properly in all UI
- Should not have any effect on any other selections from the Beta Manifest
- I've decided to hide the toggle when on a tag, so you should not expect to see it when active. 
- It downloads to the `jetpack` directory, as opposed to `jetpack-dev`. 
- Break it however you like. 

Appreciate any thoughts on making it more DRY without a significant refactor. There's a strange existing nomenclature of `branch` vs `pr` vs `tag`, that only sorta makes sense right now, but for the sake of this PR, I would like to leave refactors for future PRs. 