### PR TITLE
Switching to Live branch: Prevent code from executing after new code has been put in place.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.3 -- April 1, 2020
 
-- Avoid Fatal errors when switching between 
+- Avoid Fatal errors when switching between branches that might be at different base version of the code.
 
 ## 2.4.2 -- January 21, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.3 -- April 1, 2020
+
+- Avoid Fatal errors when switching between 
+
 ## 2.4.2 -- January 21, 2020
 
 - Avoid Fatal errors; when Jetpack's vendor directory cannot be found, do not attempt to update.

--- a/jetpack-beta-admin.php
+++ b/jetpack-beta-admin.php
@@ -96,6 +96,8 @@ class Jetpack_Beta_Admin {
 			update_option( 'jp_beta_email_notifications', (int) ! $enable_email_notifications );
 		}
 		wp_safe_redirect( Jetpack_Beta::admin_url() );
+
+		exit();
 	}
 
 	static function is_toggle_action( $option ) {

--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -3,7 +3,7 @@
  * Plugin Name: Jetpack Beta Tester
  * Plugin URI: https://jetpack.com/beta/
  * Description: Use the Beta plugin to get a sneak peek at new features and test them on your site.
- * Version: 2.4.2
+ * Version: 2.4.3
  * Author: Automattic
  * Author URI: https://jetpack.com/
  * License: GPLv2 or later
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'JPBETA__PLUGIN_FOLDER',  basename( dirname( __FILE__ ) ) );
 define( 'JPBETA__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JPBETA__PLUGIN_FILE', __FILE__ );
-define( 'JPBETA_VERSION', '2.4.2' );
+define( 'JPBETA_VERSION', '2.4.3' );
 
 define( 'JPBETA_DEFAULT_BRANCH', 'rc_only' );
 


### PR DESCRIPTION
This PR is a result of Automattic/Jetpack#15209 .

After switching to another branch that's not "current", compared to the "old" branch that we switch out of, can see warnings or errors in the error log. 

This happens because we continue executing actions and shutdown handlers after the code on the filesystem is changed and this causes a desync in what it's supposed to do. 

This PR adds a forced `exit()` after we redirect the user back to WP-Admin after the new branch has been put in place and options updated to make sure those actions and handlers are not executed and no errors are triggered.

## To test:

Since this relies on specific conditions to be met, generic testing is a bit hard.

For the moment it would work with the following instructions:

* Activate `Bleeding edge` Jetpack
* After it's activated, Activate Feature branch `fix / post by email refactoring` - Automattic/Jetpack#15139
* Without the patch this would trigger a Fatal error even in the WP-Admin UI
* With the patch you will be redirected back to WP-Admin and the branch activated.