### PR TITLE
Clear the autoloader plugin cache when the Jetpack version is changed

### DIFF
--- a/jetpack-beta.php
+++ b/jetpack-beta.php
@@ -855,6 +855,9 @@ class Jetpack_Beta {
 	}
 
 	static function replace_active_plugin( $current_plugin, $replace_with_plugin = null, $force_activate = false ) {
+		// The autoloader sets the cache in a shutdown hook. Clear it after the autoloader sets it.
+		add_action( 'shutdown', array( __CLASS__, 'clear_autoloader_plugin_cache' ), 99 );
+
 		if ( self::is_network_active() ) {
 			$new_active_plugins = array();
 			$network_active_plugins = get_site_option( 'active_sitewide_plugins' );
@@ -881,6 +884,10 @@ class Jetpack_Beta {
 			$new_active_plugins[] = $replace_with_plugin;
 		}
 		update_option( 'active_plugins', $new_active_plugins );
+	}
+
+	static function clear_autoloader_plugin_cache() {
+		delete_transient( 'jetpack_autoloader_plugin_paths' );
 	}
 
 	static function should_update_stable_version() {


### PR DESCRIPTION
Both the `jetpack` and `jetpack-dev` plugin paths can be added to the autoloader's plugin paths cache if the user switches between stable and development versions. This can result in undesirable behavior, including fatals. The autoloader will see both the `jetpack` and `jetpack-dev` plugins as active and will use the `jetpack` plugin's packages
when `jetpack-dev` is active. This happens because the autoloader prefers stable package versions.

Fix this by clearing the autoloader's plugin paths cache when the Jetpack version is changed.

#### Test

##### Reproduce the bug
1. Activate the stable version of Jetpack.
2. Activate the `fix / autoloader inclusion` branch.
3. See a fatal.

##### Test this branch.
1. Repeat the steps above. The fatal should not be generated.